### PR TITLE
[#5] implement-skill-management

### DIFF
--- a/src/__tests__/it-cli-compose-flow.test.ts
+++ b/src/__tests__/it-cli-compose-flow.test.ts
@@ -10,7 +10,10 @@ type CliModule = {
     homeDir: string;
     select: (candidates: string[]) => Promise<string>;
     input: (prompt: string, defaultValue: string) => Promise<string>;
-  }) => Promise<{ outputPath: string }>;
+  }) => Promise<
+    | { kind: 'path'; path: string }
+    | { kind: 'text'; text: string }
+  >;
 };
 
 async function loadCliModule(): Promise<CliModule> {
@@ -80,10 +83,14 @@ describe('facet compose integration flow', () => {
         return outputDir;
       },
     });
-    expect(result.outputPath.startsWith(outputDir)).toBe(true);
-    expect(existsSync(result.outputPath)).toBe(true);
+    expect(result.kind).toBe('path');
+    if (result.kind !== 'path') {
+      throw new Error('Expected path result for compose command');
+    }
+    expect(result.path.startsWith(outputDir)).toBe(true);
+    expect(existsSync(result.path)).toBe(true);
 
-    const generated = readFileSync(result.outputPath, 'utf-8');
+    const generated = readFileSync(result.path, 'utf-8');
     const systemIndex = generated.indexOf('You are a release engineer.');
     const knowledgeIndex = generated.indexOf('System architecture notes.');
     const policyIndex = generated.indexOf('Never hide errors.');
@@ -110,6 +117,20 @@ describe('facet compose integration flow', () => {
     })).rejects.toThrow('Unsupported command: unknown');
   });
 
+  it('should reject when command is missing', async () => {
+    const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-workspace-'));
+    const homeDir = mkdtempSync(join(tmpdir(), 'facet-home-'));
+    tempDirs.push(workspaceDir, homeDir);
+
+    const { runFacetCli } = await loadCliModule();
+    await expect(runFacetCli([], {
+      cwd: workspaceDir,
+      homeDir,
+      select: async () => 'unused',
+      input: async (_prompt, defaultValue) => defaultValue,
+    })).rejects.toThrow('Unsupported command: (none)');
+  });
+
   it('should initialize faceted home on first run and write output to cwd when input is blank', async () => {
     const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-workspace-'));
     const homeDir = mkdtempSync(join(tmpdir(), 'facet-home-'));
@@ -130,9 +151,13 @@ describe('facet compose integration flow', () => {
     });
 
     expect(existsSync(join(homeDir, '.faceted', 'config.yaml'))).toBe(true);
-    expect(result.outputPath).toBe(join(workspaceDir, 'default.prompt.md'));
+    expect(result.kind).toBe('path');
+    if (result.kind !== 'path') {
+      throw new Error('Expected path result for compose command');
+    }
+    expect(result.path).toBe(join(workspaceDir, 'default.prompt.md'));
 
-    const generated = readFileSync(result.outputPath, 'utf-8');
+    const generated = readFileSync(result.path, 'utf-8');
     expect(generated).toContain('# System Prompt');
     expect(generated).toContain('You are a helpful assistant.');
   });
@@ -373,7 +398,11 @@ describe('facet compose integration flow', () => {
       },
     });
 
-    expect(result.outputPath).toBe(outputPath);
+    expect(result.kind).toBe('path');
+    if (result.kind !== 'path') {
+      throw new Error('Expected path result for compose command');
+    }
+    expect(result.path).toBe(outputPath);
     expect(readFileSync(outputPath, 'utf-8')).toContain('You are a release engineer.');
   });
 

--- a/src/__tests__/it-cli-skill-flow.test.ts
+++ b/src/__tests__/it-cli-skill-flow.test.ts
@@ -1,0 +1,694 @@
+import {
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
+
+type CliModule = {
+  runFacetCli: (args: string[], options: {
+    cwd: string;
+    homeDir: string;
+    select: (candidates: string[]) => Promise<string>;
+    input: (prompt: string, defaultValue: string) => Promise<string>;
+  }) => Promise<
+    | { kind: 'path'; path: string }
+    | { kind: 'text'; text: string }
+  >;
+};
+
+async function loadCliModule(): Promise<CliModule> {
+  const modulePath = pathToFileURL(resolve('src/cli/index.ts')).href;
+  return import(modulePath) as Promise<CliModule>;
+}
+
+function createFacetedFixture(homeDir: string): {
+  facetedRoot: string;
+  facetsRoot: string;
+  compositionsRoot: string;
+} {
+  const facetedRoot = join(homeDir, '.faceted');
+  const facetsRoot = join(facetedRoot, 'facets');
+  const compositionsRoot = join(facetsRoot, 'compositions');
+
+  mkdirSync(join(facetsRoot, 'persona'), { recursive: true });
+  mkdirSync(join(facetsRoot, 'policies'), { recursive: true });
+  mkdirSync(join(facetsRoot, 'knowledge'), { recursive: true });
+  mkdirSync(compositionsRoot, { recursive: true });
+
+  writeFileSync(join(facetedRoot, 'config.yaml'), 'version: 1\n', 'utf-8');
+  writeFileSync(join(facetsRoot, 'persona', 'coder.md'), 'You are a coding agent.', 'utf-8');
+  writeFileSync(join(facetsRoot, 'persona', 'reviewer.md'), 'You are a review agent.', 'utf-8');
+  writeFileSync(join(facetsRoot, 'policies', 'coding.md'), 'Never hide errors.', 'utf-8');
+  writeFileSync(join(facetsRoot, 'policies', 'reviewing.md'), 'Review thoroughly.', 'utf-8');
+  writeFileSync(join(facetsRoot, 'knowledge', 'architecture.md'), 'Architecture reference.', 'utf-8');
+  writeFileSync(join(facetsRoot, 'knowledge', 'quality.md'), 'Quality reference.', 'utf-8');
+  writeFileSync(
+    join(compositionsRoot, 'coding.yaml'),
+    [
+      'name: coding',
+      'description: Coding workflow',
+      'persona: coder',
+      'policies:',
+      '  - coding',
+      'knowledge:',
+      '  - architecture',
+    ].join('\n'),
+    'utf-8',
+  );
+  writeFileSync(
+    join(compositionsRoot, 'review.yaml'),
+    [
+      'name: review',
+      'description: Review workflow',
+      'persona: reviewer',
+      'policies:',
+      '  - reviewing',
+      'knowledge:',
+      '  - quality',
+    ].join('\n'),
+    'utf-8',
+  );
+
+  return { facetedRoot, facetsRoot, compositionsRoot };
+}
+
+function createSelectStub(expectedSelections: readonly string[]) {
+  const queue = [...expectedSelections];
+  return async (candidates: string[]): Promise<string> => {
+    const next = queue.shift();
+    if (!next) {
+      throw new Error(`Unexpected select call: ${candidates.join(', ')}`);
+    }
+    expect(candidates).toContain(next);
+    return next;
+  };
+}
+
+describe('facet skill integration flow', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('should install Claude Code skill in inline mode and register it in skills.yaml', async () => {
+    const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-workspace-'));
+    const homeDir = mkdtempSync(join(tmpdir(), 'facet-home-'));
+    tempDirs.push(workspaceDir, homeDir);
+    createFacetedFixture(homeDir);
+
+    const skillOutputPath = join(homeDir, '.claude', 'skills', 'coding', 'SKILL.md');
+
+    const { runFacetCli } = await loadCliModule();
+
+    await runFacetCli(['install', 'skill'], {
+      cwd: workspaceDir,
+      homeDir,
+      select: createSelectStub(['coding', 'Claude Code', 'Inline']),
+      input: async (prompt, defaultValue) => {
+        if (prompt.toLowerCase().includes('output')) {
+          return skillOutputPath;
+        }
+        return defaultValue;
+      },
+    });
+
+    const skillsConfigPath = join(homeDir, '.faceted', 'skills.yaml');
+    expect(existsSync(skillsConfigPath)).toBe(true);
+
+    const skillsConfig = readFileSync(skillsConfigPath, 'utf-8');
+    expect(skillsConfig).toContain('cc:');
+    expect(skillsConfig).toContain('coding:');
+    expect(skillsConfig).toContain('source: coding.yaml');
+    expect(skillsConfig).toContain('mode: inline');
+    expect(skillsConfig).toContain(`output: ${skillOutputPath}`);
+    expect(skillsConfig).toContain('user-invocable: true');
+
+    expect(existsSync(skillOutputPath)).toBe(true);
+    const generated = readFileSync(skillOutputPath, 'utf-8');
+    expect(generated).toContain('---\nname: coding');
+    expect(generated).toContain('## Persona');
+    expect(generated).toContain('You are a coding agent.');
+    expect(generated).toContain('## Policies');
+    expect(generated).toContain('Never hide errors.');
+    expect(generated).toContain('## Knowledge');
+    expect(generated).toContain('Architecture reference.');
+  });
+
+  it('should install skill to default Claude Code output path when default input is accepted', async () => {
+    const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-workspace-'));
+    const homeDir = mkdtempSync(join(tmpdir(), 'facet-home-'));
+    tempDirs.push(workspaceDir, homeDir);
+    createFacetedFixture(homeDir);
+
+    const defaultSkillOutputPath = join(homeDir, '.claude', 'skills', 'coding', 'SKILL.md');
+
+    const { runFacetCli } = await loadCliModule();
+
+    const result = await runFacetCli(['install', 'skill'], {
+      cwd: workspaceDir,
+      homeDir,
+      select: createSelectStub(['coding', 'Claude Code', 'Inline']),
+      input: async (_prompt, defaultValue) => defaultValue,
+    });
+
+    expect(result).toEqual({
+      kind: 'path',
+      path: defaultSkillOutputPath,
+    });
+
+    expect(existsSync(defaultSkillOutputPath)).toBe(true);
+
+    const skillsConfigPath = join(homeDir, '.faceted', 'skills.yaml');
+    const skillsConfig = readFileSync(skillsConfigPath, 'utf-8');
+    expect(skillsConfig).toContain(`output: ${defaultSkillOutputPath}`);
+  });
+
+  it('should install Claude Code skill in reference mode without embedding facet bodies', async () => {
+    const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-workspace-'));
+    const homeDir = mkdtempSync(join(tmpdir(), 'facet-home-'));
+    tempDirs.push(workspaceDir, homeDir);
+    const { facetsRoot } = createFacetedFixture(homeDir);
+
+    const skillOutputPath = join(homeDir, '.claude', 'skills', 'coding', 'SKILL.md');
+    const expectedPersonaPath = join(facetsRoot, 'persona', 'coder.md');
+    const expectedPolicyPath = join(facetsRoot, 'policies', 'coding.md');
+    const expectedKnowledgePath = join(facetsRoot, 'knowledge', 'architecture.md');
+
+    const { runFacetCli } = await loadCliModule();
+
+    await runFacetCli(['install', 'skill'], {
+      cwd: workspaceDir,
+      homeDir,
+      select: createSelectStub(['coding', 'Claude Code', 'Reference']),
+      input: async (prompt, defaultValue) => {
+        if (prompt.toLowerCase().includes('output')) {
+          return skillOutputPath;
+        }
+        return defaultValue;
+      },
+    });
+
+    const generated = readFileSync(skillOutputPath, 'utf-8');
+    expect(generated).toContain(expectedPersonaPath);
+    expect(generated).toContain(expectedPolicyPath);
+    expect(generated).toContain(expectedKnowledgePath);
+    expect(generated).not.toContain('You are a coding agent.');
+    expect(generated).not.toContain('Never hide errors.');
+    expect(generated).not.toContain('Architecture reference.');
+  });
+
+  it('should update all installed skills and switch mode to reference', async () => {
+    const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-workspace-'));
+    const homeDir = mkdtempSync(join(tmpdir(), 'facet-home-'));
+    tempDirs.push(workspaceDir, homeDir);
+    const { facetsRoot } = createFacetedFixture(homeDir);
+
+    const facetedRoot = join(homeDir, '.faceted');
+    const codingSkillOutputPath = join(homeDir, '.claude', 'skills', 'coding', 'SKILL.md');
+    const reviewSkillOutputPath = join(homeDir, '.claude', 'skills', 'review', 'SKILL.md');
+    mkdirSync(dirname(codingSkillOutputPath), { recursive: true });
+    mkdirSync(dirname(reviewSkillOutputPath), { recursive: true });
+    writeFileSync(codingSkillOutputPath, 'old inline content', 'utf-8');
+    writeFileSync(reviewSkillOutputPath, 'old reference content', 'utf-8');
+    writeFileSync(
+      join(facetedRoot, 'skills.yaml'),
+      [
+        'cc:',
+        '  coding:',
+        '    source: coding.yaml',
+        '    mode: inline',
+        `    output: ${codingSkillOutputPath}`,
+        '  review:',
+        '    source: review.yaml',
+        '    mode: reference',
+        `    output: ${reviewSkillOutputPath}`,
+        '    cc:',
+        '      user-invocable: true',
+      ].join('\n'),
+      'utf-8',
+    );
+
+    const { runFacetCli } = await loadCliModule();
+
+    await runFacetCli(['update', 'skill'], {
+      cwd: workspaceDir,
+      homeDir,
+      select: createSelectStub(['All', 'Switch to Reference']),
+      input: async (_prompt, defaultValue) => defaultValue,
+    });
+
+    const updatedSkillsConfig = readFileSync(join(facetedRoot, 'skills.yaml'), 'utf-8');
+    expect(updatedSkillsConfig).toContain('coding:');
+    expect(updatedSkillsConfig).toContain('review:');
+    expect(updatedSkillsConfig).not.toContain('mode: inline');
+    expect(updatedSkillsConfig.match(/mode: reference/g)).toHaveLength(2);
+
+    const updatedCoding = readFileSync(codingSkillOutputPath, 'utf-8');
+    expect(updatedCoding).toContain(join(facetsRoot, 'persona', 'coder.md'));
+    expect(updatedCoding).not.toContain('old inline content');
+
+    const updatedReview = readFileSync(reviewSkillOutputPath, 'utf-8');
+    expect(updatedReview).toContain(join(facetsRoot, 'persona', 'reviewer.md'));
+    expect(updatedReview).not.toContain('old reference content');
+  });
+
+  it('should update selected skill and keep current mode when requested', async () => {
+    const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-workspace-'));
+    const homeDir = mkdtempSync(join(tmpdir(), 'facet-home-'));
+    tempDirs.push(workspaceDir, homeDir);
+    createFacetedFixture(homeDir);
+
+    const facetedRoot = join(homeDir, '.faceted');
+    const skillOutputPath = join(homeDir, '.claude', 'skills', 'coding', 'SKILL.md');
+    mkdirSync(dirname(skillOutputPath), { recursive: true });
+    writeFileSync(skillOutputPath, 'old inline content', 'utf-8');
+    writeFileSync(
+      join(facetedRoot, 'skills.yaml'),
+      [
+        'cc:',
+        '  coding:',
+        '    source: coding.yaml',
+        '    mode: inline',
+        `    output: ${skillOutputPath}`,
+      ].join('\n'),
+      'utf-8',
+    );
+
+    const { runFacetCli } = await loadCliModule();
+
+    await runFacetCli(['update', 'skill'], {
+      cwd: workspaceDir,
+      homeDir,
+      select: createSelectStub(['coding (cc: inline)', 'Keep current']),
+      input: async (_prompt, defaultValue) => defaultValue,
+    });
+
+    const updatedSkillsConfig = readFileSync(join(facetedRoot, 'skills.yaml'), 'utf-8');
+    expect(updatedSkillsConfig).toContain('mode: inline');
+
+    const generated = readFileSync(skillOutputPath, 'utf-8');
+    expect(generated).toContain('You are a coding agent.');
+    expect(generated).toContain('Never hide errors.');
+    expect(generated).not.toContain('old inline content');
+  });
+
+  it('should uninstall selected skill and remove generated file', async () => {
+    const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-workspace-'));
+    const homeDir = mkdtempSync(join(tmpdir(), 'facet-home-'));
+    tempDirs.push(workspaceDir, homeDir);
+    createFacetedFixture(homeDir);
+
+    const facetedRoot = join(homeDir, '.faceted');
+    const skillOutputPath = join(homeDir, '.claude', 'skills', 'coding', 'SKILL.md');
+    mkdirSync(dirname(skillOutputPath), { recursive: true });
+    writeFileSync(skillOutputPath, 'generated content', 'utf-8');
+    writeFileSync(
+      join(facetedRoot, 'skills.yaml'),
+      [
+        'cc:',
+        '  coding:',
+        '    source: coding.yaml',
+        '    mode: inline',
+        `    output: ${skillOutputPath}`,
+      ].join('\n'),
+      'utf-8',
+    );
+
+    const { runFacetCli } = await loadCliModule();
+
+    await runFacetCli(['uninstall', 'skill'], {
+      cwd: workspaceDir,
+      homeDir,
+      select: createSelectStub(['coding (cc: inline)']),
+      input: async (_prompt, defaultValue) => defaultValue,
+    });
+
+    const updatedSkillsConfig = readFileSync(join(facetedRoot, 'skills.yaml'), 'utf-8');
+    expect(updatedSkillsConfig).not.toContain('coding:');
+    expect(existsSync(skillOutputPath)).toBe(false);
+  });
+
+  it('should reject install when unsupported target is selected', async () => {
+    const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-workspace-'));
+    const homeDir = mkdtempSync(join(tmpdir(), 'facet-home-'));
+    tempDirs.push(workspaceDir, homeDir);
+    createFacetedFixture(homeDir);
+
+    const { runFacetCli } = await loadCliModule();
+
+    await expect(runFacetCli(['install', 'skill'], {
+      cwd: workspaceDir,
+      homeDir,
+      select: createSelectStub(['coding', 'Cursor', 'Inline']),
+      input: async (_prompt, defaultValue) => defaultValue,
+    })).rejects.toThrow('Unsupported skill target: Cursor');
+  });
+
+  it('should reject install when compose definition name is unsafe', async () => {
+    const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-workspace-'));
+    const homeDir = mkdtempSync(join(tmpdir(), 'facet-home-'));
+    tempDirs.push(workspaceDir, homeDir);
+    const { compositionsRoot } = createFacetedFixture(homeDir);
+    writeFileSync(
+      join(compositionsRoot, 'unsafe.yaml'),
+      [
+        'name: ../unsafe',
+        'description: Unsafe definition name',
+        'persona: coder',
+      ].join('\n'),
+      'utf-8',
+    );
+
+    const { runFacetCli } = await loadCliModule();
+
+    await expect(runFacetCli(['install', 'skill'], {
+      cwd: workspaceDir,
+      homeDir,
+      select: createSelectStub(['unsafe', 'Claude Code', 'Inline']),
+      input: async (_prompt, defaultValue) => defaultValue,
+    })).rejects.toThrow('Invalid compose definition name: ../unsafe');
+  });
+
+  it('should reject install when skill output path is outside home directory', async () => {
+    const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-workspace-'));
+    const homeDir = mkdtempSync(join(tmpdir(), 'facet-home-'));
+    tempDirs.push(workspaceDir, homeDir);
+    createFacetedFixture(homeDir);
+
+    const outsidePath = join(tmpdir(), 'outside-install-skill.md');
+    const { runFacetCli } = await loadCliModule();
+
+    await expect(runFacetCli(['install', 'skill'], {
+      cwd: workspaceDir,
+      homeDir,
+      select: createSelectStub(['coding', 'Claude Code', 'Inline']),
+      input: async (prompt, defaultValue) =>
+        prompt.toLowerCase().includes('output') ? outsidePath : defaultValue,
+    })).rejects.toThrow(`Skill output path must be inside home directory: ${outsidePath}`);
+  });
+
+  it('should reject install when skill output path points to a symbolic link', async () => {
+    const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-workspace-'));
+    const homeDir = mkdtempSync(join(tmpdir(), 'facet-home-'));
+    tempDirs.push(workspaceDir, homeDir);
+    createFacetedFixture(homeDir);
+
+    const targetPath = join(homeDir, '.claude', 'skills', 'coding', 'actual.md');
+    const symlinkPath = join(homeDir, '.claude', 'skills', 'coding', 'SKILL.md');
+    mkdirSync(dirname(symlinkPath), { recursive: true });
+    writeFileSync(targetPath, 'existing', 'utf-8');
+    symlinkSync(targetPath, symlinkPath);
+
+    const { runFacetCli } = await loadCliModule();
+
+    await expect(runFacetCli(['install', 'skill'], {
+      cwd: workspaceDir,
+      homeDir,
+      select: createSelectStub(['coding', 'Claude Code', 'Inline']),
+      input: async (prompt, defaultValue) =>
+        prompt.toLowerCase().includes('output') ? symlinkPath : defaultValue,
+    })).rejects.toThrow(`Symbolic links are not allowed for skill output file: ${symlinkPath}`);
+  });
+
+  it('should reject install when skills registry path points to a symbolic link', async () => {
+    const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-workspace-'));
+    const homeDir = mkdtempSync(join(tmpdir(), 'facet-home-'));
+    tempDirs.push(workspaceDir, homeDir);
+    createFacetedFixture(homeDir);
+
+    const facetedRoot = join(homeDir, '.faceted');
+    const registryTargetPath = join(facetedRoot, 'skills-target.yaml');
+    const registrySymlinkPath = join(facetedRoot, 'skills.yaml');
+    writeFileSync(registryTargetPath, 'cc: {}\n', 'utf-8');
+    symlinkSync(registryTargetPath, registrySymlinkPath);
+
+    const { runFacetCli } = await loadCliModule();
+
+    await expect(runFacetCli(['install', 'skill'], {
+      cwd: workspaceDir,
+      homeDir,
+      select: createSelectStub(['coding', 'Claude Code', 'Inline']),
+      input: async (_prompt, defaultValue) => defaultValue,
+    })).rejects.toThrow(
+      `Symbolic links are not allowed for skills registry file: ${registrySymlinkPath}`,
+    );
+  });
+
+  it('should reject uninstall when output path in registry is outside home directory', async () => {
+    const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-workspace-'));
+    const homeDir = mkdtempSync(join(tmpdir(), 'facet-home-'));
+    tempDirs.push(workspaceDir, homeDir);
+    createFacetedFixture(homeDir);
+
+    const facetedRoot = join(homeDir, '.faceted');
+    const outsidePath = join(tmpdir(), 'outside-skill.md');
+    writeFileSync(
+      join(facetedRoot, 'skills.yaml'),
+      [
+        'cc:',
+        '  coding:',
+        '    source: coding.yaml',
+        '    mode: inline',
+        `    output: ${outsidePath}`,
+      ].join('\n'),
+      'utf-8',
+    );
+
+    const { runFacetCli } = await loadCliModule();
+
+    await expect(runFacetCli(['uninstall', 'skill'], {
+      cwd: workspaceDir,
+      homeDir,
+      select: createSelectStub(['coding (cc: inline)']),
+      input: async (_prompt, defaultValue) => defaultValue,
+    })).rejects.toThrow(`Skill output path must be inside home directory: ${outsidePath}`);
+  });
+
+  it('should reject update when output path in registry is outside home directory', async () => {
+    const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-workspace-'));
+    const homeDir = mkdtempSync(join(tmpdir(), 'facet-home-'));
+    tempDirs.push(workspaceDir, homeDir);
+    createFacetedFixture(homeDir);
+
+    const facetedRoot = join(homeDir, '.faceted');
+    const outsidePath = join(tmpdir(), 'outside-update-skill.md');
+    writeFileSync(
+      join(facetedRoot, 'skills.yaml'),
+      [
+        'cc:',
+        '  coding:',
+        '    source: coding.yaml',
+        '    mode: inline',
+        `    output: ${outsidePath}`,
+      ].join('\n'),
+      'utf-8',
+    );
+
+    const { runFacetCli } = await loadCliModule();
+
+    await expect(runFacetCli(['update', 'skill'], {
+      cwd: workspaceDir,
+      homeDir,
+      select: createSelectStub(['coding (cc: inline)', 'Keep current']),
+      input: async (_prompt, defaultValue) => defaultValue,
+    })).rejects.toThrow(`Skill output path must be inside home directory: ${outsidePath}`);
+  });
+
+  it('should reject update when output path in registry is a symbolic link', async () => {
+    const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-workspace-'));
+    const homeDir = mkdtempSync(join(tmpdir(), 'facet-home-'));
+    tempDirs.push(workspaceDir, homeDir);
+    createFacetedFixture(homeDir);
+
+    const facetedRoot = join(homeDir, '.faceted');
+    const targetPath = join(homeDir, '.claude', 'skills', 'coding', 'actual.md');
+    const symlinkPath = join(homeDir, '.claude', 'skills', 'coding', 'SKILL.md');
+    mkdirSync(dirname(symlinkPath), { recursive: true });
+    writeFileSync(targetPath, 'existing', 'utf-8');
+    symlinkSync(targetPath, symlinkPath);
+
+    writeFileSync(
+      join(facetedRoot, 'skills.yaml'),
+      [
+        'cc:',
+        '  coding:',
+        '    source: coding.yaml',
+        '    mode: inline',
+        `    output: ${symlinkPath}`,
+      ].join('\n'),
+      'utf-8',
+    );
+
+    const { runFacetCli } = await loadCliModule();
+
+    await expect(runFacetCli(['update', 'skill'], {
+      cwd: workspaceDir,
+      homeDir,
+      select: createSelectStub(['coding (cc: inline)', 'Keep current']),
+      input: async (_prompt, defaultValue) => defaultValue,
+    })).rejects.toThrow(`Symbolic links are not allowed for skill output file: ${symlinkPath}`);
+  });
+
+  it('should reject install, update, uninstall, and list without skill subcommand', async () => {
+    const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-workspace-'));
+    const homeDir = mkdtempSync(join(tmpdir(), 'facet-home-'));
+    tempDirs.push(workspaceDir, homeDir);
+    createFacetedFixture(homeDir);
+
+    const { runFacetCli } = await loadCliModule();
+    const invalidInvocations = [
+      { args: ['install'], message: 'Unsupported command: install' },
+      { args: ['update'], message: 'Unsupported command: update' },
+      { args: ['update', 'foo'], message: 'Unsupported command: update' },
+      { args: ['uninstall'], message: 'Unsupported command: uninstall' },
+      { args: ['list'], message: 'Unsupported command: list' },
+    ];
+
+    for (const invocation of invalidInvocations) {
+      await expect(runFacetCli(invocation.args, {
+        cwd: workspaceDir,
+        homeDir,
+        select: async () => 'unused',
+        input: async (_prompt, defaultValue) => defaultValue,
+      })).rejects.toThrow(invocation.message);
+    }
+  });
+
+  it('should reject list when skills config contains unknown fields', async () => {
+    const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-workspace-'));
+    const homeDir = mkdtempSync(join(tmpdir(), 'facet-home-'));
+    tempDirs.push(workspaceDir, homeDir);
+    createFacetedFixture(homeDir);
+
+    const facetedRoot = join(homeDir, '.faceted');
+    writeFileSync(
+      join(facetedRoot, 'skills.yaml'),
+      [
+        'cc:',
+        '  coding:',
+        '    source: coding.yaml',
+        '    mode: inline',
+        '    output: ~/.claude/skills/coding/SKILL.md',
+        '    unexpected: true',
+      ].join('\n'),
+      'utf-8',
+    );
+
+    const { runFacetCli } = await loadCliModule();
+
+    await expect(runFacetCli(['list', 'skill'], {
+      cwd: workspaceDir,
+      homeDir,
+      select: async () => 'unused',
+      input: async (_prompt, defaultValue) => defaultValue,
+    })).rejects.toThrow('Invalid skills config field: cc.coding.unexpected');
+  });
+
+  it('should reject list when skills config has invalid mode', async () => {
+    const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-workspace-'));
+    const homeDir = mkdtempSync(join(tmpdir(), 'facet-home-'));
+    tempDirs.push(workspaceDir, homeDir);
+    createFacetedFixture(homeDir);
+
+    const facetedRoot = join(homeDir, '.faceted');
+    writeFileSync(
+      join(facetedRoot, 'skills.yaml'),
+      [
+        'cc:',
+        '  coding:',
+        '    source: coding.yaml',
+        '    mode: toggle',
+        '    output: ~/.claude/skills/coding/SKILL.md',
+      ].join('\n'),
+      'utf-8',
+    );
+
+    const { runFacetCli } = await loadCliModule();
+
+    await expect(runFacetCli(['list', 'skill'], {
+      cwd: workspaceDir,
+      homeDir,
+      select: async () => 'unused',
+      input: async (_prompt, defaultValue) => defaultValue,
+    })).rejects.toThrow('Invalid skills config field: cc.coding.mode');
+  });
+
+  it('should reject list when skills config output is not a string', async () => {
+    const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-workspace-'));
+    const homeDir = mkdtempSync(join(tmpdir(), 'facet-home-'));
+    tempDirs.push(workspaceDir, homeDir);
+    createFacetedFixture(homeDir);
+
+    const facetedRoot = join(homeDir, '.faceted');
+    writeFileSync(
+      join(facetedRoot, 'skills.yaml'),
+      [
+        'cc:',
+        '  coding:',
+        '    source: coding.yaml',
+        '    mode: inline',
+        '    output: 12345',
+      ].join('\n'),
+      'utf-8',
+    );
+
+    const { runFacetCli } = await loadCliModule();
+
+    await expect(runFacetCli(['list', 'skill'], {
+      cwd: workspaceDir,
+      homeDir,
+      select: async () => 'unused',
+      input: async (_prompt, defaultValue) => defaultValue,
+    })).rejects.toThrow('Invalid skills config field: cc.coding.output');
+  });
+
+  it('should list installed skills grouped by target', async () => {
+    const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-workspace-'));
+    const homeDir = mkdtempSync(join(tmpdir(), 'facet-home-'));
+    tempDirs.push(workspaceDir, homeDir);
+    createFacetedFixture(homeDir);
+
+    const facetedRoot = join(homeDir, '.faceted');
+    writeFileSync(
+      join(facetedRoot, 'skills.yaml'),
+      [
+        'cc:',
+        '  coding:',
+        '    source: coding.yaml',
+        '    mode: inline',
+        '    output: ~/.claude/skills/coding/SKILL.md',
+      ].join('\n'),
+      'utf-8',
+    );
+
+    const { runFacetCli } = await loadCliModule();
+
+    const result = await runFacetCli(['list', 'skill'], {
+      cwd: workspaceDir,
+      homeDir,
+      select: async () => {
+        throw new Error('select should not be used for list command');
+      },
+      input: async (_prompt, defaultValue) => defaultValue,
+    });
+
+    expect(result).toEqual({
+      kind: 'text',
+      text: [
+        'cc',
+        '- coding (mode: inline, source: coding.yaml, output: ~/.claude/skills/coding/SKILL.md)',
+      ].join('\n'),
+    });
+  });
+});

--- a/src/__tests__/path-guard.test.ts
+++ b/src/__tests__/path-guard.test.ts
@@ -1,0 +1,47 @@
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { ensurePathWithinHome, ensurePathWithinRoots, isWithinRoot } from '../cli/path-guard.js';
+
+describe('path guard', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('should reject paths outside home directory', () => {
+    const homeDir = mkdtempSync(join(tmpdir(), 'path-guard-home-'));
+    tempDirs.push(homeDir);
+
+    const outsidePath = join(tmpdir(), 'outside-skill.md');
+    expect(() => ensurePathWithinHome(outsidePath, homeDir, 'Skill output path')).toThrow(
+      `Skill output path must be inside home directory: ${outsidePath}`,
+    );
+  });
+
+  it('should reject symlink paths in allowed roots check', () => {
+    const rootDir = mkdtempSync(join(tmpdir(), 'path-guard-root-'));
+    tempDirs.push(rootDir);
+
+    const targetPath = join(rootDir, 'target.md');
+    const symlinkPath = join(rootDir, 'link.md');
+    writeFileSync(targetPath, 'content', 'utf-8');
+    symlinkSync(targetPath, symlinkPath);
+
+    expect(() => ensurePathWithinRoots(symlinkPath, [rootDir], 'facet file')).toThrow(
+      `Symbolic links are not allowed for facet file: ${symlinkPath}`,
+    );
+  });
+
+  it('should match exact root and descendants only', () => {
+    const root = '/tmp/root';
+
+    expect(isWithinRoot('/tmp/root', root)).toBe(true);
+    expect(isWithinRoot('/tmp/root/child', root)).toBe(true);
+    expect(isWithinRoot('/tmp/root-sibling', root)).toBe(false);
+  });
+});

--- a/src/__tests__/runner.test.ts
+++ b/src/__tests__/runner.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import { runMain } from '../cli/runner.js';
+
+describe('runner', () => {
+  it('should print generated path when runFacetCli returns path result', async () => {
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    let exitCode: number | undefined;
+
+    await runMain(['compose'], {
+      runFacetCli: async () => ({
+        kind: 'path',
+        path: '/tmp/out.prompt.md',
+      }),
+      writeStdout: message => {
+        stdout.push(message);
+      },
+      writeStderr: message => {
+        stderr.push(message);
+      },
+      setExitCode: code => {
+        exitCode = code;
+      },
+    });
+
+    expect(stdout).toEqual(['Generated: /tmp/out.prompt.md\n']);
+    expect(stderr).toEqual([]);
+    expect(exitCode).toBeUndefined();
+  });
+
+  it('should print text output when runFacetCli returns text result', async () => {
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    let exitCode: number | undefined;
+
+    await runMain(['list', 'skill'], {
+      runFacetCli: async () => ({
+        kind: 'text',
+        text: 'cc\n- coding (mode: inline, source: coding.yaml, output: ~/.claude/skills/coding/SKILL.md)',
+      }),
+      writeStdout: message => {
+        stdout.push(message);
+      },
+      writeStderr: message => {
+        stderr.push(message);
+      },
+      setExitCode: code => {
+        exitCode = code;
+      },
+    });
+
+    expect(stdout).toEqual([
+      'cc\n- coding (mode: inline, source: coding.yaml, output: ~/.claude/skills/coding/SKILL.md)\n',
+    ]);
+    expect(stderr).toEqual([]);
+    expect(exitCode).toBeUndefined();
+  });
+
+  it('should print failure message and set exit code when runFacetCli throws', async () => {
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    let exitCode: number | undefined;
+
+    await runMain(['install', 'skill'], {
+      runFacetCli: async () => {
+        throw new Error('boom');
+      },
+      writeStdout: message => {
+        stdout.push(message);
+      },
+      writeStderr: message => {
+        stderr.push(message);
+      },
+      setExitCode: code => {
+        exitCode = code;
+      },
+    });
+
+    expect(stdout).toEqual([]);
+    expect(stderr).toEqual(['facet command failed: boom\n']);
+    expect(exitCode).toBe(1);
+  });
+});

--- a/src/__tests__/skill-file-safety.test.ts
+++ b/src/__tests__/skill-file-safety.test.ts
@@ -1,0 +1,81 @@
+import { mkdtempSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { removeSkillFile, writeSkillFile } from '../cli/skill-file-ops.js';
+import { writeSkillsRegistry } from '../cli/skill-registry.js';
+
+describe('skill file safety', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('should replace skill file atomically without leaving temp files', () => {
+    const homeDir = mkdtempSync(join(tmpdir(), 'skill-file-home-'));
+    tempDirs.push(homeDir);
+
+    const outputPath = join(homeDir, '.claude', 'skills', 'coding', 'SKILL.md');
+    mkdirSync(dirname(outputPath), { recursive: true });
+    writeFileSync(outputPath, 'old', 'utf-8');
+    const oldInode = statSync(outputPath).ino;
+
+    writeSkillFile(outputPath, 'new content', homeDir);
+
+    expect(readFileSync(outputPath, 'utf-8')).toBe('new content');
+    expect(statSync(outputPath).ino).not.toBe(oldInode);
+
+    const parentEntries = readdirSync(dirname(outputPath));
+    expect(parentEntries.filter(entry => entry.includes('.tmp'))).toHaveLength(0);
+  });
+
+  it('should replace skills.yaml atomically without leaving temp files', () => {
+    const homeDir = mkdtempSync(join(tmpdir(), 'skill-registry-home-'));
+    tempDirs.push(homeDir);
+
+    const skillsPath = join(homeDir, '.faceted', 'skills.yaml');
+    mkdirSync(dirname(skillsPath), { recursive: true });
+    writeFileSync(skillsPath, 'cc:\n  old:\n    source: old.yaml\n    mode: inline\n    output: old\n', 'utf-8');
+    const oldInode = statSync(skillsPath).ino;
+
+    writeSkillsRegistry(
+      skillsPath,
+      {
+        cc: {
+          coding: {
+            source: 'coding.yaml',
+            mode: 'inline',
+            output: join(homeDir, '.claude', 'skills', 'coding', 'SKILL.md'),
+          },
+        },
+      },
+      homeDir,
+    );
+
+    const rendered = readFileSync(skillsPath, 'utf-8');
+    expect(rendered).toContain('coding:');
+    expect(rendered).toContain('source: coding.yaml');
+    expect(statSync(skillsPath).ino).not.toBe(oldInode);
+
+    const parentEntries = readdirSync(dirname(skillsPath));
+    expect(parentEntries.filter(entry => entry.includes('.tmp'))).toHaveLength(0);
+  });
+
+  it('should remove skill file without leaving quarantine files', () => {
+    const homeDir = mkdtempSync(join(tmpdir(), 'skill-remove-home-'));
+    tempDirs.push(homeDir);
+
+    const outputPath = join(homeDir, '.claude', 'skills', 'coding', 'SKILL.md');
+    mkdirSync(dirname(outputPath), { recursive: true });
+    writeFileSync(outputPath, 'generated', 'utf-8');
+
+    removeSkillFile(outputPath, homeDir);
+
+    expect(() => statSync(outputPath)).toThrow();
+    const parentEntries = readdirSync(dirname(outputPath));
+    expect(parentEntries.filter(entry => entry.includes('.delete'))).toHaveLength(0);
+  });
+});

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,173 +1,40 @@
-import { existsSync, lstatSync, readdirSync, readFileSync, realpathSync } from 'node:fs';
-import { dirname, join, resolve, sep } from 'node:path';
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
 import { compose } from '../compose.js';
 import { loadComposeDefinition } from '../compose-definition.js';
-import { getFacetedRoot, readFacetedConfig } from '../config/index.js';
+import { readFacetedConfig } from '../config/index.js';
 import { initializeFacetedHome } from '../init/index.js';
-import { isResourcePath, resolveResourcePath } from '../resolve.js';
 import { formatComposedOutput, resolveOutputDirectory, writeComposeOutput } from '../output/index.js';
-import type { FacetSet } from '../types.js';
-
-export interface FacetCliOptions {
-  readonly cwd: string;
-  readonly homeDir: string;
-  readonly select: (candidates: string[]) => Promise<string>;
-  readonly input: (prompt: string, defaultValue: string) => Promise<string>;
-}
-
-function requireFile(path: string, label: string): string {
-  if (!existsSync(path)) {
-    throw new Error(`Missing ${label}: ${path}`);
-  }
-  return readFileSync(path, 'utf-8');
-}
-
-function isWithinRoot(path: string, root: string): boolean {
-  return path === root || path.startsWith(`${root}${sep}`);
-}
-
-function ensurePathWithinRoots(path: string, roots: readonly string[], label: string): string {
-  const resolvedPath = resolve(path);
-  if (!existsSync(resolvedPath)) {
-    throw new Error(`Missing ${label}: ${resolvedPath}`);
-  }
-
-  const pathStat = lstatSync(resolvedPath);
-  if (pathStat.isSymbolicLink()) {
-    throw new Error(`Symbolic links are not allowed for ${label}: ${resolvedPath}`);
-  }
-
-  const realPath = realpathSync(resolvedPath);
-  for (const root of roots) {
-    const resolvedRoot = resolve(root);
-    const realRoot = existsSync(resolvedRoot) ? realpathSync(resolvedRoot) : resolvedRoot;
-    if (isWithinRoot(realPath, realRoot)) {
-      return realPath;
-    }
-  }
-  throw new Error(`${label} must be inside allowed facets directory: ${realPath}`);
-}
-
-function ensureSafeDefinitionName(name: string): string {
-  if (!/^[A-Za-z0-9._-]+$/u.test(name)) {
-    throw new Error(`Invalid compose definition name: ${name}`);
-  }
-  return name;
-}
+import { buildFacetSet, ensureSafeDefinitionName, listCompositionDefinitions } from './skill-renderer.js';
+import {
+  getSkillPaths,
+  runInstallSkillCommand,
+  runListSkillCommand,
+  runUninstallSkillCommand,
+  runUpdateSkillCommand,
+} from './skill-commands.js';
+import type { FacetCliOptions, FacetCliResult } from './types.js';
 
 function shouldOverwrite(answer: string): boolean {
   const normalized = answer.trim().toLowerCase();
   return normalized === 'y' || normalized === 'yes';
 }
 
-function resolveFacetRef(options: {
-  ref: string;
-  label: string;
-  baseDir: string;
-  facetDir: string;
-  allowedRoots: readonly string[];
-}): string {
-  const { ref, label, baseDir, facetDir, allowedRoots } = options;
-  if (isResourcePath(ref)) {
-    const resourcePath = resolveResourcePath(ref, baseDir);
-    const boundedPath = ensurePathWithinRoots(resourcePath, allowedRoots, label);
-    return requireFile(boundedPath, label);
+function ensureCommand(command: string | undefined): string {
+  if (!command) {
+    throw new Error('Unsupported command: (none)');
   }
-  const facetPath = join(facetDir, `${ref}.md`);
-  const boundedPath = ensurePathWithinRoots(facetPath, allowedRoots, label);
-  return requireFile(boundedPath, label);
+  return command;
 }
 
-function listCompositionDefinitions(compositionsDir: string): Record<string, string> {
-  if (!existsSync(compositionsDir)) {
-    throw new Error(`Compose definition directory does not exist: ${compositionsDir}`);
+function ensureSkillSubcommand(command: string, subcommand: string | undefined): void {
+  if (subcommand !== 'skill') {
+    throw new Error(`Unsupported command: ${command}`);
   }
-
-  const entries = readdirSync(compositionsDir, { withFileTypes: true })
-    .filter(entry => !entry.isDirectory() && (entry.name.endsWith('.yaml') || entry.name.endsWith('.yml')))
-    .map(entry => entry.name);
-
-  const definitions: Record<string, string> = {};
-  for (const entry of entries) {
-    const name = entry.replace(/\.(yaml|yml)$/u, '');
-    const definitionPath = join(compositionsDir, entry);
-    definitions[name] = ensurePathWithinRoots(
-      definitionPath,
-      [compositionsDir],
-      `compose definition "${entry}"`,
-    );
-  }
-
-  return definitions;
 }
 
-function buildFacetSet(params: {
-  definitionDir: string;
-  facetsRoot: string;
-  definition: Awaited<ReturnType<typeof loadComposeDefinition>>;
-}): FacetSet {
-  const { definitionDir, facetsRoot, definition } = params;
-  const allowedRoots = [facetsRoot];
-
-  const personaBody = resolveFacetRef({
-    ref: definition.persona,
-    label: `persona facet "${definition.persona}"`,
-    baseDir: definitionDir,
-    facetDir: join(facetsRoot, 'persona'),
-    allowedRoots,
-  });
-
-  const policies = definition.policies?.map(ref => ({
-    body: resolveFacetRef({
-      ref,
-      label: `policy facet "${ref}"`,
-      baseDir: definitionDir,
-      facetDir: join(facetsRoot, 'policies'),
-      allowedRoots,
-    }),
-  }));
-
-  const knowledge = definition.knowledge?.map(ref => ({
-    body: resolveFacetRef({
-      ref,
-      label: `knowledge facet "${ref}"`,
-      baseDir: definitionDir,
-      facetDir: join(facetsRoot, 'knowledge'),
-      allowedRoots,
-    }),
-  }));
-
-  let instructionBody: string | undefined;
-  if (definition.instruction) {
-    if (isResourcePath(definition.instruction)) {
-      const instructionPath = resolveResourcePath(definition.instruction, definitionDir);
-      const boundedPath = ensurePathWithinRoots(instructionPath, allowedRoots, 'instruction file');
-      instructionBody = requireFile(boundedPath, 'instruction file');
-    } else {
-      instructionBody = definition.instruction;
-    }
-  }
-
-  return {
-    persona: { body: personaBody },
-    policies,
-    knowledge,
-    instruction: instructionBody ? { body: instructionBody } : undefined,
-  };
-}
-
-export async function runFacetCli(args: string[], options: FacetCliOptions): Promise<{ outputPath: string }> {
-  const [command] = args;
-  if (command !== 'compose') {
-    throw new Error(`Unsupported command: ${command ?? '(none)'}`);
-  }
-
-  await initializeFacetedHome({ homeDir: options.homeDir });
-  readFacetedConfig(options.homeDir);
-
-  const facetedRoot = getFacetedRoot(options.homeDir);
-  const facetsRoot = join(facetedRoot, 'facets');
-  const compositionsDir = join(facetsRoot, 'compositions');
+async function runComposeCommand(options: FacetCliOptions): Promise<FacetCliResult> {
+  const { facetsRoot, compositionsDir } = getSkillPaths(options.homeDir);
 
   const definitionMap = listCompositionDefinitions(compositionsDir);
   const candidates = Object.keys(definitionMap).sort();
@@ -220,5 +87,45 @@ export async function runFacetCli(args: string[], options: FacetCliOptions): Pro
     overwrite,
   });
 
-  return { outputPath };
+  return {
+    kind: 'path',
+    path: outputPath,
+  };
+}
+
+export async function runFacetCli(
+  args: string[],
+  options: FacetCliOptions,
+): Promise<FacetCliResult> {
+  const command = ensureCommand(args[0]);
+  const subcommand = args[1];
+
+  await initializeFacetedHome({ homeDir: options.homeDir });
+  readFacetedConfig(options.homeDir);
+
+  if (command === 'compose') {
+    return runComposeCommand(options);
+  }
+
+  if (command === 'install') {
+    ensureSkillSubcommand(command, subcommand);
+    return runInstallSkillCommand(options);
+  }
+
+  if (command === 'update') {
+    ensureSkillSubcommand(command, subcommand);
+    return runUpdateSkillCommand(options);
+  }
+
+  if (command === 'uninstall') {
+    ensureSkillSubcommand(command, subcommand);
+    return runUninstallSkillCommand(options);
+  }
+
+  if (command === 'list') {
+    ensureSkillSubcommand(command, subcommand);
+    return runListSkillCommand(options);
+  }
+
+  throw new Error(`Unsupported command: ${command}`);
 }

--- a/src/cli/path-guard.ts
+++ b/src/cli/path-guard.ts
@@ -1,0 +1,45 @@
+import { existsSync, lstatSync, realpathSync } from 'node:fs';
+import { resolve, sep } from 'node:path';
+
+export function isWithinRoot(path: string, root: string): boolean {
+  return path === root || path.startsWith(`${root}${sep}`);
+}
+
+export function ensurePathWithinHome(
+  path: string,
+  homeDir: string,
+  label: string,
+): { resolvedPath: string; homeRealPath: string } {
+  const resolvedPath = resolve(path);
+  const resolvedHomeDir = resolve(homeDir);
+  const homeRealPath = realpathSync(resolvedHomeDir);
+
+  if (!isWithinRoot(resolvedPath, resolvedHomeDir)) {
+    throw new Error(`${label} must be inside home directory: ${resolvedPath}`);
+  }
+
+  return { resolvedPath, homeRealPath };
+}
+
+export function ensurePathWithinRoots(path: string, roots: readonly string[], label: string): string {
+  const resolvedPath = resolve(path);
+  if (!existsSync(resolvedPath)) {
+    throw new Error(`Missing ${label}: ${resolvedPath}`);
+  }
+
+  const pathStat = lstatSync(resolvedPath);
+  if (pathStat.isSymbolicLink()) {
+    throw new Error(`Symbolic links are not allowed for ${label}: ${resolvedPath}`);
+  }
+
+  const realPath = realpathSync(resolvedPath);
+  for (const root of roots) {
+    const resolvedRoot = resolve(root);
+    const realRoot = existsSync(resolvedRoot) ? realpathSync(resolvedRoot) : resolvedRoot;
+    if (isWithinRoot(realPath, realRoot)) {
+      return realPath;
+    }
+  }
+
+  throw new Error(`${label} must be inside allowed facets directory: ${realPath}`);
+}

--- a/src/cli/runner.ts
+++ b/src/cli/runner.ts
@@ -1,6 +1,7 @@
 import { homedir } from 'node:os';
 import { stdin as input, stdout as output } from 'node:process';
 import { createInterface } from 'node:readline/promises';
+import { pathToFileURL } from 'node:url';
 import { runFacetCli } from './index.js';
 import { selectInteractive } from './select.js';
 
@@ -14,19 +15,60 @@ async function inputInteractive(prompt: string, defaultValue: string): Promise<s
   }
 }
 
-export async function main(argv: string[]): Promise<void> {
-  const result = await runFacetCli(argv, {
-    cwd: process.cwd(),
-    homeDir: homedir(),
-    select: selectInteractive,
-    input: inputInteractive,
-  });
-
-  output.write(`Generated: ${result.outputPath}\n`);
+export interface RunnerDependencies {
+  readonly runFacetCli: typeof runFacetCli;
+  readonly writeStdout: (message: string) => void;
+  readonly writeStderr: (message: string) => void;
+  readonly setExitCode: (code: number) => void;
 }
 
-main(process.argv.slice(2)).catch((error: unknown) => {
-  const message = error instanceof Error ? error.message : String(error);
-  process.stderr.write(`facet compose failed: ${message}\n`);
-  process.exitCode = 1;
-});
+function defaultDependencies(): RunnerDependencies {
+  return {
+    runFacetCli,
+    writeStdout: message => {
+      output.write(message);
+    },
+    writeStderr: message => {
+      process.stderr.write(message);
+    },
+    setExitCode: code => {
+      process.exitCode = code;
+    },
+  };
+}
+
+function toErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export async function runMain(
+  argv: string[],
+  dependencies: RunnerDependencies = defaultDependencies(),
+): Promise<void> {
+  try {
+    const result = await dependencies.runFacetCli(argv, {
+      cwd: process.cwd(),
+      homeDir: homedir(),
+      select: selectInteractive,
+      input: inputInteractive,
+    });
+
+    if (result.kind === 'path') {
+      dependencies.writeStdout(`Generated: ${result.path}\n`);
+      return;
+    }
+
+    dependencies.writeStdout(`${result.text}\n`);
+  } catch (error: unknown) {
+    dependencies.writeStderr(`facet command failed: ${toErrorMessage(error)}\n`);
+    dependencies.setExitCode(1);
+  }
+}
+
+export async function main(argv: string[]): Promise<void> {
+  await runMain(argv);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  void main(process.argv.slice(2));
+}

--- a/src/cli/skill-commands.ts
+++ b/src/cli/skill-commands.ts
@@ -1,0 +1,296 @@
+import { basename } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
+import { loadComposeDefinition } from '../compose-definition.js';
+import { getFacetedRoot } from '../config/index.js';
+import {
+  buildSkillSections,
+  ensureSafeDefinitionName,
+  listCompositionDefinitions,
+  renderSkillDocument,
+  resolveDefinitionPathFromSource,
+} from './skill-renderer.js';
+import { buildInstalledSkillLabels, readSkillsRegistry, writeSkillsRegistry } from './skill-registry.js';
+import { removeSkillFile, writeSkillFile } from './skill-file-ops.js';
+import type { SkillEntry, SkillMode, SkillsRegistry } from './skill-types.js';
+import type { FacetCliOptions, FacetCliResult } from './types.js';
+
+function ensureSkillModeFromLabel(modeLabel: string): SkillMode {
+  if (modeLabel === 'Inline') {
+    return 'inline';
+  }
+  if (modeLabel === 'Reference') {
+    return 'reference';
+  }
+  throw new Error(`Unsupported skill mode: ${modeLabel}`);
+}
+
+function resolveTargetModeFromDecision(modeDecision: string): SkillMode | undefined {
+  if (modeDecision === 'Keep current') {
+    return undefined;
+  }
+  if (modeDecision === 'Switch to Reference') {
+    return 'reference';
+  }
+  if (modeDecision === 'Switch to Inline') {
+    return 'inline';
+  }
+  throw new Error(`Unsupported skill mode decision: ${modeDecision}`);
+}
+
+function resolveInstallTarget(targetLabel: string): 'cc' {
+  if (targetLabel === 'Claude Code') {
+    return 'cc';
+  }
+  throw new Error(`Unsupported skill target: ${targetLabel}`);
+}
+
+function defaultOutputPath(homeDir: string, skillName: string): string {
+  return join(homeDir, '.claude', 'skills', skillName, 'SKILL.md');
+}
+
+export function getSkillPaths(homeDir: string): {
+  readonly facetedRoot: string;
+  readonly facetsRoot: string;
+  readonly compositionsDir: string;
+  readonly skillsPath: string;
+} {
+  const facetedRoot = getFacetedRoot(homeDir);
+  const facetsRoot = join(facetedRoot, 'facets');
+
+  return {
+    facetedRoot,
+    facetsRoot,
+    compositionsDir: join(facetsRoot, 'compositions'),
+    skillsPath: join(facetedRoot, 'skills.yaml'),
+  };
+}
+
+async function generateAndWriteSkill(params: {
+  entry: { source: string; mode: SkillMode; outputPath: string };
+  compositionsDir: string;
+  facetsRoot: string;
+  homeDir: string;
+}): Promise<void> {
+  const definitionPath = resolveDefinitionPathFromSource(params.entry.source, params.compositionsDir);
+  const definition = await loadComposeDefinition(definitionPath);
+  const definitionDir = dirname(definitionPath);
+
+  const sections = buildSkillSections({
+    definition,
+    definitionDir,
+    facetsRoot: params.facetsRoot,
+  });
+
+  const content = renderSkillDocument({
+    ...sections,
+    mode: params.entry.mode,
+  });
+
+  writeSkillFile(params.entry.outputPath, content, params.homeDir);
+}
+
+export async function runInstallSkillCommand(options: FacetCliOptions): Promise<FacetCliResult> {
+  const { facetsRoot, compositionsDir, skillsPath } = getSkillPaths(options.homeDir);
+  const registry = readSkillsRegistry(skillsPath);
+
+  const definitionMap = listCompositionDefinitions(compositionsDir);
+  const compositionCandidates = Object.keys(definitionMap).sort();
+  if (compositionCandidates.length === 0) {
+    throw new Error(`No compose definitions found in ${compositionsDir}`);
+  }
+
+  const selectedComposition = await options.select(compositionCandidates);
+  const definitionPath = definitionMap[selectedComposition];
+  if (!definitionPath) {
+    throw new Error(`Unknown compose definition selected: ${selectedComposition}`);
+  }
+
+  const targetLabel = await options.select(['Claude Code', 'Cursor', 'Cline']);
+  const target = resolveInstallTarget(targetLabel);
+
+  const modeLabel = await options.select(['Inline', 'Reference']);
+  const mode = ensureSkillModeFromLabel(modeLabel);
+
+  const definition = await loadComposeDefinition(definitionPath);
+  const source = basename(definitionPath);
+  const safeSkillName = ensureSafeDefinitionName(definition.name);
+  const defaultPath = defaultOutputPath(options.homeDir, safeSkillName);
+  const outputPath = resolve(await options.input('Output path', defaultPath));
+
+  await generateAndWriteSkill({
+    entry: {
+      source,
+      mode,
+      outputPath,
+    },
+    compositionsDir,
+    facetsRoot,
+    homeDir: options.homeDir,
+  });
+
+  const targetEntries = registry[target] ?? {};
+  const updatedTargetEntries = {
+    ...targetEntries,
+    [safeSkillName]: {
+      source,
+      mode,
+      output: outputPath,
+      cc: { 'user-invocable': true },
+    },
+  };
+  const updatedRegistry = {
+    ...registry,
+    [target]: updatedTargetEntries,
+  };
+
+  writeSkillsRegistry(skillsPath, updatedRegistry, options.homeDir);
+  return {
+    kind: 'path',
+    path: outputPath,
+  };
+}
+
+export async function runUpdateSkillCommand(options: FacetCliOptions): Promise<FacetCliResult> {
+  const { facetsRoot, compositionsDir, skillsPath } = getSkillPaths(options.homeDir);
+  const registry = readSkillsRegistry(skillsPath);
+  const installed = buildInstalledSkillLabels(registry);
+  if (installed.length === 0) {
+    throw new Error('No installed skills to update');
+  }
+
+  const selection = await options.select(['All', ...installed.map(item => item.label)]);
+
+  const selectedEntries =
+    selection === 'All' ? installed : installed.filter(item => item.label === selection);
+
+  if (selectedEntries.length === 0) {
+    throw new Error(`Unknown installed skill selected: ${selection}`);
+  }
+
+  const modeDecision = await options.select([
+    'Keep current',
+    selectedEntries.some(item => item.entry.mode === 'inline')
+      ? 'Switch to Reference'
+      : 'Switch to Inline',
+  ]);
+
+  const targetMode = resolveTargetModeFromDecision(modeDecision);
+
+  let updatedRegistry: SkillsRegistry = { ...registry };
+
+  for (const selected of selectedEntries) {
+    const nextMode = targetMode ?? selected.entry.mode;
+
+    await generateAndWriteSkill({
+      entry: {
+        source: selected.entry.source,
+        mode: nextMode,
+        outputPath: selected.entry.output,
+      },
+      compositionsDir,
+      facetsRoot,
+      homeDir: options.homeDir,
+    });
+
+    const targetEntries = updatedRegistry[selected.target];
+    if (!targetEntries) {
+      throw new Error(`Invalid skills registry target: ${selected.target}`);
+    }
+
+    const current = targetEntries[selected.skillName];
+    if (!current) {
+      throw new Error(`Invalid skills registry entry: ${selected.target}.${selected.skillName}`);
+    }
+
+    const updatedTargetEntries = {
+      ...targetEntries,
+      [selected.skillName]: {
+        ...current,
+        mode: nextMode,
+      },
+    };
+    updatedRegistry = {
+      ...updatedRegistry,
+      [selected.target]: updatedTargetEntries,
+    };
+  }
+
+  writeSkillsRegistry(skillsPath, updatedRegistry, options.homeDir);
+  return {
+    kind: 'text',
+    text: 'Updated skill(s)',
+  };
+}
+
+export async function runUninstallSkillCommand(options: FacetCliOptions): Promise<FacetCliResult> {
+  const { skillsPath } = getSkillPaths(options.homeDir);
+  const registry = readSkillsRegistry(skillsPath);
+  const installed = buildInstalledSkillLabels(registry);
+  if (installed.length === 0) {
+    throw new Error('No installed skills to uninstall');
+  }
+
+  const selection = await options.select(installed.map(item => item.label));
+  const targetSelection = installed.find(item => item.label === selection);
+  if (!targetSelection) {
+    throw new Error(`Unknown installed skill selected: ${selection}`);
+  }
+
+  removeSkillFile(targetSelection.entry.output, options.homeDir);
+
+  const targetEntries = registry[targetSelection.target];
+  if (!targetEntries) {
+    throw new Error(`Invalid skills registry target: ${targetSelection.target}`);
+  }
+
+  const updatedTargetEntries = Object.fromEntries(
+    Object.entries(targetEntries).filter(([skillName]) => skillName !== targetSelection.skillName),
+  );
+  const baseRegistry = Object.fromEntries(
+    Object.entries(registry).filter(([target]) => target !== targetSelection.target),
+  ) as SkillsRegistry;
+
+  const updatedRegistry =
+    Object.keys(updatedTargetEntries).length > 0
+      ? {
+          ...baseRegistry,
+          [targetSelection.target]: updatedTargetEntries,
+        }
+      : baseRegistry;
+
+  writeSkillsRegistry(skillsPath, updatedRegistry, options.homeDir);
+  return {
+    kind: 'path',
+    path: targetSelection.entry.output,
+  };
+}
+
+export async function runListSkillCommand(options: FacetCliOptions): Promise<FacetCliResult> {
+  const { skillsPath } = getSkillPaths(options.homeDir);
+  const registry = readSkillsRegistry(skillsPath);
+
+  const lines: string[] = [];
+  for (const target of Object.keys(registry).sort()) {
+    const entries = registry[target];
+    if (!entries || Object.keys(entries).length === 0) {
+      continue;
+    }
+
+    lines.push(target);
+    for (const skillName of Object.keys(entries).sort()) {
+      const entry: SkillEntry | undefined = entries[skillName];
+      if (!entry) {
+        continue;
+      }
+
+      lines.push(
+        `- ${skillName} (mode: ${entry.mode}, source: ${entry.source}, output: ${entry.output})`,
+      );
+    }
+  }
+
+  return {
+    kind: 'text',
+    text: lines.join('\n'),
+  };
+}

--- a/src/cli/skill-file-ops.ts
+++ b/src/cli/skill-file-ops.ts
@@ -1,0 +1,122 @@
+import {
+  closeSync,
+  constants,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { basename, dirname, join } from 'node:path';
+import { ensurePathWithinHome, isWithinRoot } from './path-guard.js';
+
+function ensureParentPathWithinHome(resolvedPath: string, homeRealPath: string): string {
+  const outputParentDirectory = dirname(resolvedPath);
+  mkdirSync(outputParentDirectory, { recursive: true });
+  const outputParentRealPath = realpathSync(outputParentDirectory);
+  if (!isWithinRoot(outputParentRealPath, homeRealPath)) {
+    throw new Error(`Skill output path escapes home directory: ${resolvedPath}`);
+  }
+  return outputParentRealPath;
+}
+
+function buildTemporaryPath(targetPath: string, parentRealPath: string): string {
+  return join(parentRealPath, `.${basename(targetPath)}.${process.pid}.${Date.now()}.tmp`);
+}
+
+function resolveOutputTargetPathForWrite(
+  resolvedPath: string,
+  homeRealPath: string,
+): { outputParentRealPath: string; outputTargetPath: string } {
+  const outputParentRealPath = ensureParentPathWithinHome(resolvedPath, homeRealPath);
+  const outputTargetPath = join(outputParentRealPath, basename(resolvedPath));
+  return { outputParentRealPath, outputTargetPath };
+}
+
+function resolveOutputTargetPathForRemoval(resolvedPath: string, homeRealPath: string): string {
+  const outputParentRealPath = realpathSync(dirname(resolvedPath));
+  if (!isWithinRoot(outputParentRealPath, homeRealPath)) {
+    throw new Error(`Skill output path escapes home directory: ${resolvedPath}`);
+  }
+  return join(outputParentRealPath, basename(resolvedPath));
+}
+
+function writeFreshFile(path: string, content: string): void {
+  const openFlags = constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW;
+
+  let fileDescriptor: number;
+  try {
+    fileDescriptor = openSync(path, openFlags, 0o600);
+  } catch (error: unknown) {
+    const errorCode = (error as NodeJS.ErrnoException).code;
+    if (errorCode === 'ELOOP') {
+      throw new Error(`Symbolic links are not allowed for skill output file: ${path}`);
+    }
+    throw error;
+  }
+
+  try {
+    writeFileSync(fileDescriptor, content, 'utf-8');
+  } finally {
+    closeSync(fileDescriptor);
+  }
+}
+
+export function writeSkillFile(outputPath: string, content: string, homeDir: string): void {
+  const { resolvedPath, homeRealPath } = ensurePathWithinHome(outputPath, homeDir, 'Skill output path');
+  const { outputParentRealPath, outputTargetPath } = resolveOutputTargetPathForWrite(
+    resolvedPath,
+    homeRealPath,
+  );
+  const tempOutputPath = buildTemporaryPath(outputTargetPath, outputParentRealPath);
+
+  try {
+    if (existsSync(outputTargetPath) && lstatSync(outputTargetPath).isSymbolicLink()) {
+      throw new Error(`Symbolic links are not allowed for skill output file: ${resolvedPath}`);
+    }
+
+    writeFreshFile(tempOutputPath, content);
+    renameSync(tempOutputPath, outputTargetPath);
+  } catch (error) {
+    if (existsSync(tempOutputPath)) {
+      unlinkSync(tempOutputPath);
+    }
+    throw error;
+  }
+
+  const outputRealPath = realpathSync(outputTargetPath);
+  if (!isWithinRoot(outputRealPath, homeRealPath)) {
+    throw new Error(`Skill output path escapes home directory: ${resolvedPath}`);
+  }
+}
+
+export function removeSkillFile(outputPath: string, homeDir: string): void {
+  const { resolvedPath, homeRealPath } = ensurePathWithinHome(outputPath, homeDir, 'Skill output path');
+
+  if (!existsSync(resolvedPath)) {
+    return;
+  }
+
+  const outputTargetPath = resolveOutputTargetPathForRemoval(resolvedPath, homeRealPath);
+  const fileStat = lstatSync(outputTargetPath);
+  if (fileStat.isSymbolicLink()) {
+    throw new Error(`Symbolic links are not allowed for skill output file: ${resolvedPath}`);
+  }
+
+  const fileRealPath = realpathSync(outputTargetPath);
+  if (!isWithinRoot(fileRealPath, homeRealPath)) {
+    throw new Error(`Skill output path escapes home directory: ${resolvedPath}`);
+  }
+
+  const outputParentRealPath = ensureParentPathWithinHome(outputTargetPath, homeRealPath);
+  const quarantinePath = join(
+    outputParentRealPath,
+    `.${basename(outputTargetPath)}.${process.pid}.${Date.now()}.delete`,
+  );
+  renameSync(outputTargetPath, quarantinePath);
+  rmSync(quarantinePath, { force: true });
+}

--- a/src/cli/skill-registry.ts
+++ b/src/cli/skill-registry.ts
@@ -1,0 +1,198 @@
+import {
+  closeSync,
+  constants,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { basename, dirname, join } from 'node:path';
+import { parse, stringify } from 'yaml';
+import { ensurePathWithinHome, isWithinRoot } from './path-guard.js';
+import type { SkillEntry, SkillMode, SkillsRegistry } from './skill-types.js';
+
+function ensureObject(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`Invalid skills config field: ${label}`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function ensureNonEmptyString(value: unknown, label: string): string {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Error(`Invalid skills config field: ${label}`);
+  }
+  return value;
+}
+
+function ensureSkillMode(value: unknown, label: string): SkillMode {
+  if (value !== 'inline' && value !== 'reference') {
+    throw new Error(`Invalid skills config field: ${label}`);
+  }
+  return value;
+}
+
+function parseSkillEntry(value: unknown, label: string): SkillEntry {
+  const entryObject = ensureObject(value, label);
+  const allowedKeys = new Set(['source', 'mode', 'output', 'cc']);
+  for (const key of Object.keys(entryObject)) {
+    if (!allowedKeys.has(key)) {
+      throw new Error(`Invalid skills config field: ${label}.${key}`);
+    }
+  }
+
+  const source = ensureNonEmptyString(entryObject.source, `${label}.source`);
+  const mode = ensureSkillMode(entryObject.mode, `${label}.mode`);
+  const output = ensureNonEmptyString(entryObject.output, `${label}.output`);
+
+  let cc: SkillEntry['cc'];
+  if (entryObject.cc !== undefined) {
+    const ccObject = ensureObject(entryObject.cc, `${label}.cc`);
+    const ccAllowedKeys = new Set(['user-invocable']);
+    for (const ccKey of Object.keys(ccObject)) {
+      if (!ccAllowedKeys.has(ccKey)) {
+        throw new Error(`Invalid skills config field: ${label}.cc.${ccKey}`);
+      }
+    }
+
+    if (ccObject['user-invocable'] !== undefined && typeof ccObject['user-invocable'] !== 'boolean') {
+      throw new Error(`Invalid skills config field: ${label}.cc.user-invocable`);
+    }
+
+    cc = {
+      'user-invocable': ccObject['user-invocable'] as boolean | undefined,
+    };
+  }
+
+  return {
+    source,
+    mode,
+    output,
+    cc,
+  };
+}
+
+export function readSkillsRegistry(skillsPath: string): SkillsRegistry {
+  if (!existsSync(skillsPath)) {
+    return {};
+  }
+
+  const parsed = parse(readFileSync(skillsPath, 'utf-8'));
+  if (parsed === null || parsed === undefined) {
+    return {};
+  }
+
+  const root = ensureObject(parsed, 'root');
+  const registry: SkillsRegistry = {};
+  for (const [target, targetValue] of Object.entries(root)) {
+    const targetObject = ensureObject(targetValue, target);
+    const targetEntries: Record<string, SkillEntry> = {};
+
+    for (const [skillName, entry] of Object.entries(targetObject)) {
+      targetEntries[skillName] = parseSkillEntry(entry, `${target}.${skillName}`);
+    }
+
+    registry[target] = targetEntries;
+  }
+
+  return registry;
+}
+
+export function writeSkillsRegistry(skillsPath: string, registry: SkillsRegistry, homeDir: string): void {
+  const { resolvedPath, homeRealPath } = ensurePathWithinHome(
+    skillsPath,
+    homeDir,
+    'Skills registry path',
+  );
+
+  mkdirSync(dirname(resolvedPath), { recursive: true });
+  const registryParentRealPath = realpathSync(dirname(resolvedPath));
+  if (!isWithinRoot(registryParentRealPath, homeRealPath)) {
+    throw new Error(`Skills registry path escapes home directory: ${resolvedPath}`);
+  }
+  const registryTargetPath = join(registryParentRealPath, basename(resolvedPath));
+
+  const rendered = stringify(registry);
+  const openFlags = constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW;
+  const tempRegistryPath = join(
+    registryParentRealPath,
+    `.${basename(resolvedPath)}.${process.pid}.${Date.now()}.tmp`,
+  );
+
+  let fileDescriptor: number;
+  try {
+    if (existsSync(registryTargetPath) && lstatSync(registryTargetPath).isSymbolicLink()) {
+      throw new Error(`Symbolic links are not allowed for skills registry file: ${resolvedPath}`);
+    }
+
+    fileDescriptor = openSync(tempRegistryPath, openFlags, 0o600);
+  } catch (error: unknown) {
+    const errorCode = (error as NodeJS.ErrnoException).code;
+    if (errorCode === 'ELOOP') {
+      throw new Error(`Symbolic links are not allowed for skills registry file: ${resolvedPath}`);
+    }
+    throw error;
+  }
+
+  try {
+    writeFileSync(fileDescriptor, rendered.endsWith('\n') ? rendered : `${rendered}\n`, 'utf-8');
+  } finally {
+    closeSync(fileDescriptor);
+  }
+
+  try {
+    renameSync(tempRegistryPath, registryTargetPath);
+  } catch (error) {
+    if (existsSync(tempRegistryPath)) {
+      unlinkSync(tempRegistryPath);
+    }
+    throw error;
+  }
+
+  const registryRealPath = realpathSync(registryTargetPath);
+  if (!isWithinRoot(registryRealPath, homeRealPath)) {
+    throw new Error(`Skills registry path escapes home directory: ${resolvedPath}`);
+  }
+}
+
+export function buildInstalledSkillLabels(registry: SkillsRegistry): Array<{
+  readonly label: string;
+  readonly target: string;
+  readonly skillName: string;
+  readonly entry: SkillEntry;
+}> {
+  const labels: Array<{
+    readonly label: string;
+    readonly target: string;
+    readonly skillName: string;
+    readonly entry: SkillEntry;
+  }> = [];
+
+  for (const target of Object.keys(registry).sort()) {
+    const entries = registry[target];
+    if (!entries) {
+      continue;
+    }
+
+    for (const skillName of Object.keys(entries).sort()) {
+      const entry = entries[skillName];
+      if (!entry) {
+        continue;
+      }
+
+      labels.push({
+        label: `${skillName} (${target}: ${entry.mode})`,
+        target,
+        skillName,
+        entry,
+      });
+    }
+  }
+
+  return labels;
+}

--- a/src/cli/skill-renderer.ts
+++ b/src/cli/skill-renderer.ts
@@ -1,0 +1,245 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { isResourcePath, resolveResourcePath } from '../resolve.js';
+import { ensurePathWithinRoots } from './path-guard.js';
+import type { ComposeDefinition, FacetSet } from '../types.js';
+import type {
+  InstructionSection,
+  ResolvedDefinitionSections,
+  SkillDocumentInput,
+  SkillSection,
+} from './skill-types.js';
+
+function requireFile(path: string, label: string): string {
+  if (!existsSync(path)) {
+    throw new Error(`Missing ${label}: ${path}`);
+  }
+  return readFileSync(path, 'utf-8');
+}
+
+export function ensureSafeDefinitionName(name: string): string {
+  if (!/^[A-Za-z0-9._-]+$/u.test(name)) {
+    throw new Error(`Invalid compose definition name: ${name}`);
+  }
+  return name;
+}
+
+function resolveFacetRefContent(options: {
+  ref: string;
+  label: string;
+  baseDir: string;
+  facetDir: string;
+  allowedRoots: readonly string[];
+}): { body: string; path: string } {
+  const { ref, label, baseDir, facetDir, allowedRoots } = options;
+  if (isResourcePath(ref)) {
+    const resourcePath = resolveResourcePath(ref, baseDir);
+    const boundedPath = ensurePathWithinRoots(resourcePath, allowedRoots, label);
+    return { path: boundedPath, body: requireFile(boundedPath, label) };
+  }
+
+  const facetPath = join(facetDir, `${ref}.md`);
+  const boundedPath = ensurePathWithinRoots(facetPath, allowedRoots, label);
+  return { path: boundedPath, body: requireFile(boundedPath, label) };
+}
+
+export function resolveDefinitionSections(params: {
+  definition: ComposeDefinition;
+  definitionDir: string;
+  facetsRoot: string;
+}): ResolvedDefinitionSections {
+  const { definition, definitionDir, facetsRoot } = params;
+  const allowedRoots = [facetsRoot];
+
+  const personaContent = resolveFacetRefContent({
+    ref: definition.persona,
+    label: `persona facet "${definition.persona}"`,
+    baseDir: definitionDir,
+    facetDir: join(facetsRoot, 'persona'),
+    allowedRoots,
+  });
+
+  const policies: SkillSection[] =
+    definition.policies?.map(ref => {
+      const resolved = resolveFacetRefContent({
+        ref,
+        label: `policy facet "${ref}"`,
+        baseDir: definitionDir,
+        facetDir: join(facetsRoot, 'policies'),
+        allowedRoots,
+      });
+      return { ref, body: resolved.body, path: resolved.path };
+    }) ?? [];
+
+  const knowledge: SkillSection[] =
+    definition.knowledge?.map(ref => {
+      const resolved = resolveFacetRefContent({
+        ref,
+        label: `knowledge facet "${ref}"`,
+        baseDir: definitionDir,
+        facetDir: join(facetsRoot, 'knowledge'),
+        allowedRoots,
+      });
+      return { ref, body: resolved.body, path: resolved.path };
+    }) ?? [];
+
+  let instruction: InstructionSection | undefined;
+  if (definition.instruction) {
+    if (isResourcePath(definition.instruction)) {
+      const resolved = resolveFacetRefContent({
+        ref: definition.instruction,
+        label: 'instruction file',
+        baseDir: definitionDir,
+        facetDir: facetsRoot,
+        allowedRoots,
+      });
+      instruction = {
+        ref: definition.instruction,
+        body: resolved.body,
+        path: resolved.path,
+      };
+    } else {
+      instruction = {
+        ref: 'literal',
+        body: definition.instruction,
+      };
+    }
+  }
+
+  return {
+    persona: {
+      ref: definition.persona,
+      body: personaContent.body,
+      path: personaContent.path,
+    },
+    policies,
+    knowledge,
+    instruction,
+  };
+}
+
+export function listCompositionDefinitions(compositionsDir: string): Record<string, string> {
+  if (!existsSync(compositionsDir)) {
+    throw new Error(`Compose definition directory does not exist: ${compositionsDir}`);
+  }
+
+  const entries = readdirSync(compositionsDir, { withFileTypes: true })
+    .filter(entry => !entry.isDirectory() && (entry.name.endsWith('.yaml') || entry.name.endsWith('.yml')))
+    .map(entry => entry.name);
+
+  const definitions: Record<string, string> = {};
+  for (const entry of entries) {
+    const name = entry.replace(/\.(yaml|yml)$/u, '');
+    const definitionPath = join(compositionsDir, entry);
+    definitions[name] = ensurePathWithinRoots(
+      definitionPath,
+      [compositionsDir],
+      `compose definition "${entry}"`,
+    );
+  }
+
+  return definitions;
+}
+
+export function buildFacetSet(params: {
+  definitionDir: string;
+  facetsRoot: string;
+  definition: ComposeDefinition;
+}): FacetSet {
+  const resolved = resolveDefinitionSections(params);
+
+  return {
+    persona: { body: resolved.persona.body },
+    policies: resolved.policies.map(policy => ({ body: policy.body })),
+    knowledge: resolved.knowledge.map(item => ({ body: item.body })),
+    instruction: resolved.instruction ? { body: resolved.instruction.body } : undefined,
+  };
+}
+
+export function buildSkillSections(params: {
+  definition: ComposeDefinition;
+  definitionDir: string;
+  facetsRoot: string;
+}): Omit<SkillDocumentInput, 'mode'> {
+  const { definition } = params;
+  const resolved = resolveDefinitionSections(params);
+
+  return {
+    definition,
+    persona: resolved.persona,
+    policies: resolved.policies,
+    knowledge: resolved.knowledge,
+    instruction: resolved.instruction,
+  };
+}
+
+function makeSkillHeader(definition: ComposeDefinition): string {
+  const lines = ['---', `name: ${definition.name}`];
+  if (definition.description) {
+    lines.push(`description: ${definition.description}`);
+  }
+  lines.push('---');
+  return lines.join('\n');
+}
+
+function hasInstructionPath(instruction: InstructionSection): instruction is SkillSection {
+  return instruction.ref !== 'literal';
+}
+
+export function renderSkillDocument(input: SkillDocumentInput): string {
+  const lines: string[] = [];
+
+  lines.push(makeSkillHeader(input.definition));
+  lines.push('');
+  lines.push('<!-- Generated by faceted-prompting. Do not edit manually. -->');
+  lines.push('');
+
+  lines.push('## Persona');
+  lines.push('');
+  lines.push(input.mode === 'inline' ? input.persona.body : input.persona.path);
+  lines.push('');
+
+  if (input.policies.length > 0) {
+    lines.push('## Policies');
+    lines.push('');
+    for (const policy of input.policies) {
+      lines.push(`### ${policy.ref}`);
+      lines.push('');
+      lines.push(input.mode === 'inline' ? policy.body : policy.path);
+      lines.push('');
+    }
+  }
+
+  if (input.knowledge.length > 0) {
+    lines.push('## Knowledge');
+    lines.push('');
+    for (const knowledge of input.knowledge) {
+      lines.push(`### ${knowledge.ref}`);
+      lines.push('');
+      lines.push(input.mode === 'inline' ? knowledge.body : knowledge.path);
+      lines.push('');
+    }
+  }
+
+  if (input.instruction) {
+    lines.push('## Instruction');
+    lines.push('');
+
+    if (input.mode === 'reference' && hasInstructionPath(input.instruction)) {
+      lines.push(input.instruction.path);
+    } else {
+      lines.push(input.instruction.body);
+    }
+    lines.push('');
+  }
+
+  return `${lines.join('\n').trimEnd()}\n`;
+}
+
+export function resolveDefinitionPathFromSource(source: string, compositionsDir: string): string {
+  return ensurePathWithinRoots(
+    join(compositionsDir, source),
+    [compositionsDir],
+    `compose definition "${source}"`,
+  );
+}

--- a/src/cli/skill-types.ts
+++ b/src/cli/skill-types.ts
@@ -1,0 +1,43 @@
+import type { ComposeDefinition } from '../types.js';
+
+export type SkillMode = 'inline' | 'reference';
+
+export interface SkillEntry {
+  readonly source: string;
+  readonly mode: SkillMode;
+  readonly output: string;
+  readonly cc?: {
+    readonly 'user-invocable'?: boolean;
+  };
+}
+
+export type SkillsRegistry = Record<string, Record<string, SkillEntry>>;
+
+export interface FacetRefContent {
+  readonly body: string;
+  readonly path: string;
+}
+
+export interface SkillSection {
+  readonly ref: string;
+  readonly body: string;
+  readonly path: string;
+}
+
+export type InstructionSection = SkillSection | { readonly ref: 'literal'; readonly body: string };
+
+export interface SkillDocumentInput {
+  readonly definition: ComposeDefinition;
+  readonly mode: SkillMode;
+  readonly persona: SkillSection;
+  readonly policies: readonly SkillSection[];
+  readonly knowledge: readonly SkillSection[];
+  readonly instruction?: InstructionSection;
+}
+
+export interface ResolvedDefinitionSections {
+  readonly persona: SkillSection;
+  readonly policies: readonly SkillSection[];
+  readonly knowledge: readonly SkillSection[];
+  readonly instruction?: InstructionSection;
+}

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -1,0 +1,16 @@
+export interface FacetCliOptions {
+  readonly cwd: string;
+  readonly homeDir: string;
+  readonly select: (candidates: string[]) => Promise<string>;
+  readonly input: (prompt: string, defaultValue: string) => Promise<string>;
+}
+
+export type FacetCliResult =
+  | {
+      readonly kind: 'path';
+      readonly path: string;
+    }
+  | {
+      readonly kind: 'text';
+      readonly text: string;
+    };


### PR DESCRIPTION
## Summary

## 概要

faceted-prompting の compose 定義から、AIコーディングエージェント（Claude Code, Cursor, Cline 等）のスキルファイルを生成・管理する機能。

## コマンド体系

```bash
facet install skill      # 新規インストール（対話）
facet update skill       # 更新（対話）
facet uninstall skill    # 削除（対話）
facet list skill         # インストール済み一覧
```

## `facet install skill` フロー

すべて対話形式:

```
$ facet install skill

? Select composition:
  > coding
    book-writing
    review

? Select target:
  > Claude Code
    Cursor
    Cline

? Mode:
  > Inline (embed facet contents)
    Reference (file paths)

? Output path: ~/.claude/skills/coding/SKILL.md

✓ Installed coding → ~/.claude/skills/coding/SKILL.md
```

## `facet update skill` フロー

```
$ facet update skill

? Select skill to update:
  > All
    coding (cc: inline)
    book-writing (cc: ref)

? Change mode? (currently: inline)
  > Keep current
    Switch to Reference

✓ Updated coding → ~/.claude/skills/coding/SKILL.md
```

## 設計方針

### compose 定義は純粋に保つ

compose 定義（`~/.faceted/facets/compositions/*.yaml`）はファセットの構成のみ。ターゲット固有の設定は持たない。

```yaml
# ~/.faceted/facets/compositions/coding.yaml
name: coding
description: コードを書くときの思考プロセス
persona: coder
policies:
  - coding
  - ai-antipattern
knowledge:
  - architecture
```

### 管理ファイル

`~/.faceted/skills.yaml` でインストール済みスキルを管理。ターゲットごとにグルーピング:

```yaml
cc:
  coding:
    source: coding.yaml
    mode: inline
    output: ~/.claude/skills/coding/SKILL.md
    cc:
      user-invocable: true
cursor:
  coding:
    source: coding.yaml
    mode: inline
    output: ~/.cursor/rules/coding.mdc
```

同じ compose 定義を複数ターゲットに配れる。

### 生成戦略: Inline / Reference のハイブリッド

- **Inline**: ファセット内容を SKILL.md に直接埋め込む。自己完結。更新時は `facet update skill` で再生成
- **Reference**: ファイルパスを記述し、エージェントが実行時に Read する。ファセット更新が即反映

### ターゲット別出力

各ターゲットのスキルフォーマットに合わせて出力を変換:

| Target | 出力先 | フォーマット |
|--------|--------|-------------|
| Claude Code | `~/.claude/skills/<name>/SKILL.md` | YAML frontmatter + Markdown |
| Cursor | TBD | TBD |
| Cline | TBD | TBD |

### Claude Code SKILL.md の生成イメージ（Inline）

```markdown
---
name: coding
description: コードを書くときの思考プロセス
---

<!-- Generated by faceted-prompting. Do not edit manually. -->

## Persona

{coder.md の中身}

## Policies

### coding
{coding.md の中身}

### ai-antipattern
{ai-antipattern.md の中身}

## Knowledge

### architecture
{architecture.md の中身}
```

## 注意点

- persona / policy / knowledge の区別は、Claude Code スキルではフラットなプロンプトになる（system/user の区別なし）。セクション見出しで表現
- truncation は不要（エージェント側のコンテキスト管理に委ねる）
- Cursor / Cline 等のフォーマットは別途調査が必要

## スコープ外

- `facet compose` の既存機能への変更
- ターゲット固有設定を compose 定義に持たせること

## Execution Report

Piece `takt-default` completed successfully.

Closes #5