### PR TITLE
[#7] migrate-config-precedence

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "traced-config": "^0.1.0",
         "yaml": "^2.8.1"
       },
       "bin": {
@@ -21,7 +22,7 @@
         "vitest": "^3.2.4"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -2379,6 +2380,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/traced-config": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/traced-config/-/traced-config-0.1.0.tgz",
+      "integrity": "sha512-GW8EZPMEDNWQfAubJ5qU5hVk5DawKRPrysQQlztsIuGIUsNWV51/Rc5RXViD5xbhFPeSqqwcRnVIStfpjm2JaA==",
+      "license": "MIT",
+      "dependencies": {
+        "yaml": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "devDependencies": {
     "@types/node": "^22.19.11",
@@ -44,6 +44,7 @@
     "vitest": "^3.2.4"
   },
   "dependencies": {
+    "traced-config": "^0.1.0",
     "yaml": "^2.8.1"
   }
 }

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -1,0 +1,117 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
+
+type ConfigModule = {
+  readFacetedConfig: (homeDir: string) => Promise<{
+    version: number;
+    skillPaths?: readonly string[];
+  }>;
+};
+
+async function loadConfigModule(): Promise<ConfigModule> {
+  const modulePath = pathToFileURL(resolve('src/config/index.ts')).href;
+  return import(modulePath) as Promise<ConfigModule>;
+}
+
+function writeConfig(homeDir: string, body: string): void {
+  const facetedRoot = join(homeDir, '.faceted');
+  mkdirSync(facetedRoot, { recursive: true });
+  writeFileSync(join(facetedRoot, 'config.yaml'), body, 'utf-8');
+}
+
+describe('readFacetedConfig', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('should resolve config values from config.yaml when fields are explicitly provided', async () => {
+    const homeDir = mkdtempSync(join(tmpdir(), 'faceted-config-'));
+    tempDirs.push(homeDir);
+    writeConfig(homeDir, ['version: 2', 'skillPaths:', '  - /skills/custom'].join('\n'));
+
+    const { readFacetedConfig } = await loadConfigModule();
+    const config = await readFacetedConfig(homeDir);
+
+    expect(config).toEqual({
+      version: 2,
+      skillPaths: ['/skills/custom'],
+    });
+  });
+
+  it('should prioritize config.yaml values over default layer on conflict', async () => {
+    const homeDir = mkdtempSync(join(tmpdir(), 'faceted-config-'));
+    tempDirs.push(homeDir);
+    writeConfig(homeDir, ['version: 9', 'skillPaths:', '  - /skills/override'].join('\n'));
+
+    const { readFacetedConfig } = await loadConfigModule();
+    const config = await readFacetedConfig(homeDir);
+
+    expect(config.version).toBe(9);
+    expect(config.skillPaths).toEqual(['/skills/override']);
+  });
+
+  it('should fill skillPaths from default layer when config.yaml omits the field', async () => {
+    const homeDir = mkdtempSync(join(tmpdir(), 'faceted-config-'));
+    tempDirs.push(homeDir);
+    writeConfig(homeDir, 'version: 1\n');
+
+    const { readFacetedConfig } = await loadConfigModule();
+    const config = await readFacetedConfig(homeDir);
+
+    expect(config.skillPaths).toEqual([]);
+  });
+
+  it('should fill version from default layer when config.yaml omits the field', async () => {
+    const homeDir = mkdtempSync(join(tmpdir(), 'faceted-config-'));
+    tempDirs.push(homeDir);
+    writeConfig(homeDir, 'skillPaths: []\n');
+
+    const { readFacetedConfig } = await loadConfigModule();
+    const config = await readFacetedConfig(homeDir);
+
+    expect(config.version).toBe(1);
+  });
+
+  it('should throw when skillPaths contains non-string entries', async () => {
+    const homeDir = mkdtempSync(join(tmpdir(), 'faceted-config-'));
+    tempDirs.push(homeDir);
+    writeConfig(homeDir, ['version: 1', 'skillPaths:', '  - 100'].join('\n'));
+
+    const { readFacetedConfig } = await loadConfigModule();
+
+    await expect(readFacetedConfig(homeDir)).rejects.toThrow(
+      'Invalid faceted config field: skillPaths',
+    );
+  });
+
+  it('should throw an invalid file error when config.yaml contains malformed yaml', async () => {
+    const homeDir = mkdtempSync(join(tmpdir(), 'faceted-config-'));
+    tempDirs.push(homeDir);
+    writeConfig(homeDir, 'version: [1\n');
+
+    const { readFacetedConfig } = await loadConfigModule();
+
+    await expect(readFacetedConfig(homeDir)).rejects.toThrow(
+      `Invalid faceted config file: ${join(homeDir, '.faceted', 'config.yaml')}`,
+    );
+  });
+
+  it('should throw when config.yaml parses to a non-object root value', async () => {
+    const homeDir = mkdtempSync(join(tmpdir(), 'faceted-config-'));
+    tempDirs.push(homeDir);
+    writeConfig(homeDir, '- not-an-object\n');
+
+    const { readFacetedConfig } = await loadConfigModule();
+
+    await expect(readFacetedConfig(homeDir)).rejects.toThrow(
+      `Invalid faceted config file: ${join(homeDir, '.faceted', 'config.yaml')}`,
+    );
+  });
+});

--- a/src/__tests__/it-cli-compose-flow.test.ts
+++ b/src/__tests__/it-cli-compose-flow.test.ts
@@ -131,6 +131,25 @@ describe('facet compose integration flow', () => {
     })).rejects.toThrow('Unsupported command: (none)');
   });
 
+  it('should fail compose command when config file is malformed', async () => {
+    const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-workspace-'));
+    const homeDir = mkdtempSync(join(tmpdir(), 'facet-home-'));
+    tempDirs.push(workspaceDir, homeDir);
+
+    const facetedRoot = join(homeDir, '.faceted');
+    mkdirSync(facetedRoot, { recursive: true });
+    const configPath = join(facetedRoot, 'config.yaml');
+    writeFileSync(configPath, 'version: [1\n', 'utf-8');
+
+    const { runFacetCli } = await loadCliModule();
+    await expect(runFacetCli(['compose'], {
+      cwd: workspaceDir,
+      homeDir,
+      select: async () => 'unused',
+      input: async (_prompt, defaultValue) => defaultValue,
+    })).rejects.toThrow(`Invalid faceted config file: ${configPath}`);
+  });
+
   it('should initialize faceted home on first run and write output to cwd when input is blank', async () => {
     const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-workspace-'));
     const homeDir = mkdtempSync(join(tmpdir(), 'facet-home-'));

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -101,7 +101,7 @@ export async function runFacetCli(
   const subcommand = args[1];
 
   await initializeFacetedHome({ homeDir: options.homeDir });
-  readFacetedConfig(options.homeDir);
+  await readFacetedConfig(options.homeDir);
 
   if (command === 'compose') {
     return runComposeCommand(options);

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,5 +1,6 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { tracedConfig } from 'traced-config';
 import { parse } from 'yaml';
 
 export interface FacetedConfig {
@@ -44,18 +45,51 @@ function ensureStringList(value: unknown, field: string): string[] | undefined {
   return value;
 }
 
-export function readFacetedConfig(homeDir: string): FacetedConfig {
+export async function readFacetedConfig(homeDir: string): Promise<FacetedConfig> {
   const configPath = getConfigPath(homeDir);
   if (!existsSync(configPath)) {
     throw new Error(`Missing faceted config: ${configPath}`);
   }
 
-  const parsed = parse(readFileSync(configPath, 'utf-8'));
-  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-    throw new Error(`Invalid faceted config file: ${configPath}`);
+  const resolver = tracedConfig({
+    schema: {
+      version: {
+        default: 1,
+        doc: 'config schema version',
+        sources: { global: false, local: true, env: false, cli: false },
+      },
+      skillPaths: {
+        default: [],
+        doc: 'skill path list',
+        sources: { global: false, local: true, env: false, cli: false },
+      },
+    },
+  });
+
+  resolver.addParser('yaml', content => {
+    const parsed = parse(content);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new Error(`Invalid faceted config file: ${configPath}`);
+    }
+    return parsed;
+  });
+
+  try {
+    await resolver.loadFile([{ path: configPath, label: 'local' }]);
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message === `Failed to parse config file '${configPath}' (label: local)`
+    ) {
+      throw new Error(`Invalid faceted config file: ${configPath}`);
+    }
+    throw error;
   }
 
-  const config = parsed as Record<string, unknown>;
+  const config = {
+    version: resolver.get('version'),
+    skillPaths: resolver.get('skillPaths'),
+  };
   return {
     version: ensureNumber(config.version, 'version'),
     skillPaths: ensureStringList(config.skillPaths, 'skillPaths'),


### PR DESCRIPTION
## Summary

# タスク指示書: `traced-config` を使った設定**読み込み優先順位**解決への移行

## 目的
`faceted-prompting` の config 拡張に備え、既存の設定**読み込み時の優先順位解決**を `traced-config` ベースへ移行する。  
ユーザー指示により、対象は**書き込み処理ではない**。

## スコープ
- 対象: config の読み込み・優先順位解決・マージ経路
- 非対象: config ファイル書き込み処理の置き換え/移行

## 参照資料
- リポジトリ内の設定読み込み実装:
  - `src/config/**`（存在する場合）
  - `src/**/config*.ts` / `src/**/config*.js`
  - `src/**/load*config*.ts` / `src/**/load*config*.js`
- 設定利用側（読み込み結果を参照する箇所）:
  - `src/**/cli/**`
  - `src/**/commands/**`
  - `src/**/services/**`
- 依存関係と実行定義:
  - `package.json`
  - lockfile（`package-lock.json` / `pnpm-lock.yaml` / `yarn.lock`）

## 作業項目（優先度つき）

### 高: 設定読み込み優先順位解決の `traced-config` 化
- 対象モジュール:
  - 既存の config 読み込み/マージ責務を持つモジュール（実コード調査で特定したファイル）
- 作業内容:
  - `traced-config` を依存追加し、既存の手書き優先順位ロジックを置換する
  - 現在使っている設定ソース（例: デフォルト値・ファイル・環境変数・CLI引数など）を実装から特定し、`traced-config` のレイヤーとして実装する
  - 優先順位決定を単一点（resolver/loader）に集約し、利用側はその出力のみ参照する形に整理する
  - 既存 API 互換は、明示指示がない限り不要。不要になった旧優先順位コードは削除する

### 高: 書き込み処理を変更しないことの担保
- 対象モジュール:
  - config 書き込み責務のあるモジュール（実コード調査で特定）
- 作業内容:
  - 書き込み処理は変更しない
  - 読み込み改修の影響で書き込み側に型・呼び出し変更が波及した場合は、読み込み境界側で吸収し、書き込みロジックは維持する

### 中: テスト追加・更新（先にテスト作成、次に実装）
- 対象ファイル:
  - 既存 config テスト群（`src/**/__tests__/**`, `test/**` など実コード調査で特定）
  - 必要に応じて新規テストファイル作成
- 作業内容:
  - 優先順位解決の単体テストを追加（正常系/競合時/欠損時/境界値）
  - 既存ワークフローに設定値が渡る統合テストが必要なら追加
  - テストは Given-When-Then で 1 テスト 1 概念に分離

### 低: ドキュメント・開発者向け説明の更新
- 対象ファイル:
  - README / docs 内の config 説明箇所（存在する場合）
- 作業内容:
  - 「読み込み優先順位」の記述を実装と一致させる
  - `traced-config` 採用後の優先順位ルールを明記する

## 再現手順（現状問題の確認）
1. 設定値が重複する複数ソース（例: config ファイルと環境変数）を用意する。  
2. 現在の実装で最終的に採用される値を確認し、期待優先順位とズレるケースを特定する。  
3. 同ケースで改修後に `traced-config` による優先順位解決が期待どおりになることを確認する。

## 確認方法（完了条件）
1. 依存関係に `traced-config` が追加され、読み込み経路で実際に使用されている。  
2. 既存の手書き優先順位解決ロジックが置換または削除されている。  
3. 書き込み処理モジュールに意図しない変更がない。  
4. 追加/更新したテストが通過する（プロジェクト標準の test コマンド）。  
5. 設定競合時に、定義した優先順位どおりの値が確実に選ばれる。

## Open Questions
- 優先順位の最終仕様（どのソースが最優先か）の確定値。  
  - 既存実装・既存テスト・既存ドキュメントから一意に決まる場合はそれを採用し、決まらない場合のみユーザー確認。

## Execution Report

Piece `takt-default` completed successfully.

Closes #7