### PR TITLE
[#9] refactor-traced-config

### DIFF
--- a/src/__tests__/config.traced-config.test.ts
+++ b/src/__tests__/config.traced-config.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import * as fs from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
@@ -11,118 +11,121 @@ type ConfigModule = {
   }>;
 };
 
-type ResolverMock = {
-  addParser: ReturnType<typeof vi.fn>;
-  addFormat: ReturnType<typeof vi.fn>;
-  loadFile: ReturnType<typeof vi.fn>;
-  validate: ReturnType<typeof vi.fn>;
-  get: ReturnType<typeof vi.fn>;
-};
-
-function createResolverMock(): ResolverMock {
-  return {
-    addParser: vi.fn(),
-    addFormat: vi.fn(),
-    loadFile: vi.fn(),
-    validate: vi.fn(),
-    get: vi.fn(),
-  };
-}
-
-async function loadConfigModuleWithResolver(resolver: ResolverMock): Promise<ConfigModule> {
-  const tracedConfigMock = vi.fn(() => resolver);
-  vi.resetModules();
-  vi.doMock('traced-config', () => ({ tracedConfig: tracedConfigMock }));
-
+async function loadConfigModule(): Promise<ConfigModule> {
   const modulePath = pathToFileURL(resolve('src/config/index.ts')).href;
-  const cacheKey = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
-  const module = await import(`${modulePath}?case=${cacheKey}`);
-  return module as ConfigModule;
+  return import(modulePath) as Promise<ConfigModule>;
 }
 
 function writeConfig(homeDir: string, body: string): string {
   const facetedRoot = join(homeDir, '.faceted');
-  mkdirSync(facetedRoot, { recursive: true });
+  fs.mkdirSync(facetedRoot, { recursive: true });
   const configPath = join(facetedRoot, 'config.yaml');
-  writeFileSync(configPath, body, 'utf-8');
+  fs.writeFileSync(configPath, body, 'utf-8');
   return configPath;
 }
 
-describe('readFacetedConfig with traced-config error handling', () => {
+describe('readFacetedConfig traced-config integration', () => {
   const tempDirs: string[] = [];
 
   afterEach(() => {
-    vi.doUnmock('traced-config');
+    vi.restoreAllMocks();
+    vi.doUnmock('yaml');
     vi.resetModules();
     for (const dir of tempDirs) {
-      rmSync(dir, { recursive: true, force: true });
+      fs.rmSync(dir, { recursive: true, force: true });
     }
   });
 
-  it('should normalize parse errors even when traced-config message has extra details', async () => {
-    const homeDir = mkdtempSync(join(tmpdir(), 'faceted-config-mock-'));
+  it('loads a valid object-root yaml file', async () => {
+    const homeDir = fs.mkdtempSync(join(tmpdir(), 'faceted-config-real-'));
     tempDirs.push(homeDir);
-    const configPath = writeConfig(homeDir, 'version: [1\n');
+    writeConfig(homeDir, 'version: 2\nskillPaths:\n  - /skills/custom\n');
 
-    const resolver = createResolverMock();
-    resolver.loadFile.mockRejectedValue(
-      new Error(`Failed to parse config file '${configPath}' (label: local): yaml parser detail`),
-    );
+    const { readFacetedConfig } = await loadConfigModule();
+    const config = await readFacetedConfig(homeDir);
 
-    const { readFacetedConfig } = await loadConfigModuleWithResolver(resolver);
+    expect(config).toEqual({
+      version: 2,
+      skillPaths: ['/skills/custom'],
+    });
+  });
+
+  it('fails when yaml root is an array', async () => {
+    const homeDir = fs.mkdtempSync(join(tmpdir(), 'faceted-config-real-'));
+    tempDirs.push(homeDir);
+    const configPath = writeConfig(homeDir, '- item\n');
+
+    const { readFacetedConfig } = await loadConfigModule();
 
     await expect(readFacetedConfig(homeDir)).rejects.toThrow(
       `Invalid faceted config file: ${configPath}`,
     );
-    expect(resolver.addParser).not.toHaveBeenCalled();
-    expect(resolver.addFormat).toHaveBeenCalledWith('string-list', expect.any(Function));
   });
 
-  it('should throw invalid field error when traced-config validate reports schema issues', async () => {
-    const homeDir = mkdtempSync(join(tmpdir(), 'faceted-config-mock-'));
+  it('fails when yaml root is a scalar', async () => {
+    const homeDir = fs.mkdtempSync(join(tmpdir(), 'faceted-config-real-'));
     tempDirs.push(homeDir);
-    writeConfig(homeDir, 'version: 1\nskillPaths:\n  - /skills/custom\n');
+    const configPath = writeConfig(homeDir, 'hello\n');
 
-    const resolver = createResolverMock();
-    resolver.loadFile.mockResolvedValue(undefined);
-    resolver.validate.mockReturnValue([{ key: 'skillPaths' }]);
-    resolver.get.mockImplementation((key: string) => {
-      if (key === 'version') {
-        return 1;
-      }
-      if (key === 'skillPaths') {
-        return ['/skills/custom'];
-      }
-      return undefined;
-    });
+    const { readFacetedConfig } = await loadConfigModule();
 
-    const { readFacetedConfig } = await loadConfigModuleWithResolver(resolver);
+    await expect(readFacetedConfig(homeDir)).rejects.toThrow(
+      `Invalid faceted config file: ${configPath}`,
+    );
+  });
+
+  it('returns invalid field using validation issue key', async () => {
+    const homeDir = fs.mkdtempSync(join(tmpdir(), 'faceted-config-real-'));
+    tempDirs.push(homeDir);
+    writeConfig(homeDir, 'version: 1\nskillPaths:\n  - 100\n');
+
+    const { readFacetedConfig } = await loadConfigModule();
 
     await expect(readFacetedConfig(homeDir)).rejects.toThrow(
       'Invalid faceted config field: skillPaths',
     );
   });
 
-  it('should throw a generic field error when validate reports an issue without key metadata', async () => {
-    const homeDir = mkdtempSync(join(tmpdir(), 'faceted-config-mock-'));
+  it('fails when yaml is malformed', async () => {
+    const homeDir = fs.mkdtempSync(join(tmpdir(), 'faceted-config-real-'));
     tempDirs.push(homeDir);
-    writeConfig(homeDir, 'version: 1\nskillPaths:\n  - /skills/custom\n');
+    const configPath = writeConfig(homeDir, 'version: [1\n');
 
-    const resolver = createResolverMock();
-    resolver.loadFile.mockResolvedValue(undefined);
-    resolver.validate.mockReturnValue([{}]);
-    resolver.get.mockImplementation((key: string) => {
-      if (key === 'version') {
-        return 1;
-      }
-      if (key === 'skillPaths') {
-        return ['/skills/custom'];
-      }
-      return undefined;
+    const { readFacetedConfig } = await loadConfigModule();
+
+    await expect(readFacetedConfig(homeDir)).rejects.toThrow(
+      `Invalid faceted config file: ${configPath}`,
+    );
+  });
+
+  it('uses a single file read during one config load', async () => {
+    const homeDir = fs.mkdtempSync(join(tmpdir(), 'faceted-config-real-'));
+    tempDirs.push(homeDir);
+    const configPath = writeConfig(homeDir, 'version: 2\nskillPaths:\n  - /skills/custom\n');
+
+    let parseCallCount = 0;
+    vi.resetModules();
+    vi.doMock('yaml', async () => {
+      const actual = await vi.importActual<typeof import('yaml')>('yaml');
+      return {
+        ...actual,
+        parse: (...args: Parameters<typeof actual.parse>) => {
+          parseCallCount += 1;
+          if (parseCallCount === 1) {
+            fs.writeFileSync(configPath, '- broken-after-first-read\n', 'utf-8');
+          }
+          return actual.parse(...args);
+        },
+      };
     });
 
-    const { readFacetedConfig } = await loadConfigModuleWithResolver(resolver);
+    const { readFacetedConfig } = await loadConfigModule();
+    const config = await readFacetedConfig(homeDir);
 
-    await expect(readFacetedConfig(homeDir)).rejects.toThrow('Invalid faceted config field');
+    expect(config).toEqual({
+      version: 2,
+      skillPaths: ['/skills/custom'],
+    });
+    expect(parseCallCount).toBe(1);
   });
 });

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,6 +1,6 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { tracedConfig } from 'traced-config';
+import { tracedConfig, type ValidateError } from 'traced-config';
 import { parse } from 'yaml';
 
 export interface FacetedConfig {
@@ -28,32 +28,20 @@ export function ensureConfigFile(homeDir: string): void {
   }
 }
 
-function getInvalidFieldFromValidationIssue(issue: unknown): string | undefined {
-  if (typeof issue === 'string' && issue.length > 0) {
-    return issue;
-  }
-  if (!issue || typeof issue !== 'object') {
-    return undefined;
-  }
-
-  const record = issue as Record<string, unknown>;
-  const key = record.key;
-  if (typeof key === 'string' && key.length > 0) {
-    return key;
-  }
-  const field = record.field;
-  if (typeof field === 'string' && field.length > 0) {
-    return field;
-  }
-  return undefined;
-}
-
-function assertConfigRootIsObject(configPath: string): void {
-  const content = readFileSync(configPath, 'utf-8');
+function parseConfigRootAsObject(content: string): Record<string, unknown> {
   const parsed = parse(content);
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-    throw new Error(`Invalid faceted config file: ${configPath}`);
+    throw new Error('Config root must be an object');
   }
+  return parsed as Record<string, unknown>;
+}
+
+function hasErrorCode(error: unknown): error is NodeJS.ErrnoException {
+  if (typeof error !== 'object' || error === null) {
+    return false;
+  }
+  const withCode = error as { code?: unknown };
+  return typeof withCode.code === 'string';
 }
 
 export async function readFacetedConfig(homeDir: string): Promise<FacetedConfig> {
@@ -82,24 +70,21 @@ export async function readFacetedConfig(homeDir: string): Promise<FacetedConfig>
   resolver.addFormat('string-list', value => {
     return Array.isArray(value) && value.every(item => typeof item === 'string');
   });
+  resolver.addParser('yaml', parseConfigRootAsObject);
+  resolver.addParser('yml', parseConfigRootAsObject);
 
   try {
     await resolver.loadFile([{ path: configPath, label: 'local' }]);
   } catch (error) {
-    if (
-      error instanceof Error &&
-      error.message.startsWith(`Failed to parse config file '${configPath}' (label: local)`)
-    ) {
-      throw new Error(`Invalid faceted config file: ${configPath}`);
+    if (hasErrorCode(error)) {
+      throw error;
     }
-    throw error;
+    throw new Error(`Invalid faceted config file: ${configPath}`);
   }
 
-  assertConfigRootIsObject(configPath);
-
-  const validationIssues = resolver.validate();
+  const validationIssues: ValidateError[] = resolver.validate();
   if (validationIssues.length > 0) {
-    const invalidField = getInvalidFieldFromValidationIssue(validationIssues[0]);
+    const invalidField = validationIssues[0]?.key;
     if (invalidField) {
       throw new Error(`Invalid faceted config field: ${invalidField}`);
     }


### PR DESCRIPTION
## Summary

## 背景

PR #8 で `traced-config` を導入した。動作上問題ないが、以下の改善点がある。

## 改善項目

### 1. エラーメッセージ文字列マッチの脆弱性

`readFacetedConfig` 内で `traced-config` の内部エラーメッセージに完全一致で依存している。

```ts
if (
  error instanceof Error &&
  error.message === `Failed to parse config file '${configPath}' (label: local)`
)
```

ライブラリ側のメッセージ変更で壊れる。カスタムパーサー内で直接エラーを throw するか、部分一致に変更する。

### 2. 組み込み YAML パーサーの不要な上書き

`traced-config` は YAML パーサーを内蔵しているが、`addParser('yaml', ...)` で上書きしている。目的は non-object root のバリデーションのみ。`loadFile` 後に別途チェックする方がパーサーの責務として素直。

### 3. `ensureNumber` / `ensureStringList` の二重バリデーション

traced-config のスキーマ `format` + `validate()` で代替可能。現状は手動バリデーションとスキーマが二重に存在している。スキーマのカスタムフォーマットに寄せて一本化する。

### 4. `tracedConfig()` の毎回生成

`readFacetedConfig` 呼び出しごとにスキーマ登録・パーサー登録・ファイル読み込みが走る。現状は CLI 起動時に1回なので問題ないが、呼び出し頻度が増える場合は初期化を分離する。

## 関連

- #8

## Execution Report

Piece `takt-default` completed successfully.

Closes #9