### PR TITLE
[#15] local-default-facet-init

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,5 +55,6 @@
   "dependencies": {
     "traced-config": "^0.1.0",
     "yaml": "^2.8.1"
-  }
+  },
+  "packageManager": "pnpm@10.32.1+sha512.a706938f0e89ac1456b6563eab4edf1d1faf3368d1191fc5c59790e96dc918e4456ab2e67d613de1043d2e8c81f87303e6b40d4ffeca9df15ef1ad567348f2be"
 }

--- a/src/__tests__/init-test-style-regression.test.ts
+++ b/src/__tests__/init-test-style-regression.test.ts
@@ -1,0 +1,10 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('init test style regression', () => {
+  it('should keep Given/When/Then comments out of init.test.ts', () => {
+    const initTestBody = readFileSync(resolve('src/__tests__/init.test.ts'), 'utf-8');
+    expect(initTestBody).not.toMatch(/\/\/\s*(Given|When|Then)\b/u);
+  });
+});

--- a/src/__tests__/init.test.ts
+++ b/src/__tests__/init.test.ts
@@ -5,7 +5,15 @@ import { pathToFileURL } from 'node:url';
 import { afterEach, describe, expect, it } from 'vitest';
 
 type InitModule = {
-  initializeFacetedHome: (options: { homeDir: string }) => Promise<void>;
+  initializeLocalFaceted: (options: { cwd: string }) => Promise<void>;
+  initializeGlobalFaceted: (options: {
+    homeDir: string;
+    fetchImpl?: (input: string) => Promise<{
+      ok: boolean;
+      status: number;
+      text(): Promise<string>;
+    }>;
+  }) => Promise<void>;
   pullSampleFacets: (options: {
     homeDir: string;
     fetchImpl?: (input: string) => Promise<{
@@ -22,7 +30,7 @@ async function loadInitModule(): Promise<InitModule> {
   return import(modulePath) as Promise<InitModule>;
 }
 
-describe('initializeFacetedHome', () => {
+describe('initializeLocalFaceted', () => {
   const tempDirs: string[] = [];
 
   afterEach(() => {
@@ -31,28 +39,31 @@ describe('initializeFacetedHome', () => {
     }
   });
 
-  it('should create config and required facet directories on first run', async () => {
-    const homeDir = mkdtempSync(join(tmpdir(), 'faceted-home-'));
-    tempDirs.push(homeDir);
+  it('should create config and required facet directories under cwd on first run', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'faceted-workspace-'));
+    const unrelatedHomeDir = mkdtempSync(join(tmpdir(), 'faceted-home-'));
+    tempDirs.push(cwd, unrelatedHomeDir);
 
-    const { initializeFacetedHome } = await loadInitModule();
-    await initializeFacetedHome({ homeDir });
-    expect(existsSync(join(homeDir, '.faceted', 'config.yaml'))).toBe(true);
-    expect(existsSync(join(homeDir, '.faceted', 'facets', 'persona'))).toBe(true);
-    expect(existsSync(join(homeDir, '.faceted', 'facets', 'knowledge'))).toBe(true);
-    expect(existsSync(join(homeDir, '.faceted', 'facets', 'policies'))).toBe(true);
-    expect(existsSync(join(homeDir, '.faceted', 'compositions'))).toBe(true);
-    expect(existsSync(join(homeDir, '.faceted', 'templates'))).toBe(true);
+    const { initializeLocalFaceted } = await loadInitModule();
+    await initializeLocalFaceted({ cwd });
+
+    expect(existsSync(join(cwd, '.faceted', 'config.yaml'))).toBe(true);
+    expect(existsSync(join(cwd, '.faceted', 'facets', 'persona'))).toBe(true);
+    expect(existsSync(join(cwd, '.faceted', 'facets', 'knowledge'))).toBe(true);
+    expect(existsSync(join(cwd, '.faceted', 'facets', 'policies'))).toBe(true);
+    expect(existsSync(join(cwd, '.faceted', 'compositions'))).toBe(true);
+    expect(existsSync(join(cwd, '.faceted', 'templates'))).toBe(true);
+    expect(existsSync(join(unrelatedHomeDir, '.faceted'))).toBe(false);
   });
 
-  it('should create empty composition and template directories on first run', async () => {
-    const homeDir = mkdtempSync(join(tmpdir(), 'faceted-home-'));
-    tempDirs.push(homeDir);
+  it('should not install sample composition and template files in local init', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'faceted-workspace-'));
+    tempDirs.push(cwd);
 
-    const { initializeFacetedHome } = await loadInitModule();
-    await initializeFacetedHome({ homeDir });
+    const { initializeLocalFaceted } = await loadInitModule();
+    await initializeLocalFaceted({ cwd });
 
-    const facetedRoot = join(homeDir, '.faceted');
+    const facetedRoot = join(cwd, '.faceted');
     const facetsRoot = join(facetedRoot, 'facets');
     expect(existsSync(join(facetsRoot, 'persona', 'coder.md'))).toBe(false);
     expect(existsSync(join(facetsRoot, 'knowledge', 'architecture.md'))).toBe(false);
@@ -63,39 +74,27 @@ describe('initializeFacetedHome', () => {
     expect(existsSync(join(facetedRoot, 'templates', 'issue-worktree', 'README.md'))).toBe(false);
   });
 
-  it('should not install sample composition or template content during init', async () => {
-    const homeDir = mkdtempSync(join(tmpdir(), 'faceted-home-'));
-    tempDirs.push(homeDir);
-
-    const { initializeFacetedHome } = await loadInitModule();
-    await initializeFacetedHome({ homeDir });
-
-    const facetedRoot = join(homeDir, '.faceted');
-    expect(existsSync(join(facetedRoot, 'compositions', 'issue-worktree.yaml'))).toBe(false);
-    expect(existsSync(join(facetedRoot, 'templates', 'issue-worktree', 'SKILL.md'))).toBe(false);
-  });
-
   it('should initialize config with extensible skillPaths field', async () => {
-    const homeDir = mkdtempSync(join(tmpdir(), 'faceted-home-'));
-    tempDirs.push(homeDir);
+    const cwd = mkdtempSync(join(tmpdir(), 'faceted-workspace-'));
+    tempDirs.push(cwd);
 
-    const { initializeFacetedHome } = await loadInitModule();
-    await initializeFacetedHome({ homeDir });
+    const { initializeLocalFaceted } = await loadInitModule();
+    await initializeLocalFaceted({ cwd });
 
-    const configPath = join(homeDir, '.faceted', 'config.yaml');
+    const configPath = join(cwd, '.faceted', 'config.yaml');
     const configBody = readFileSync(configPath, 'utf-8');
     expect(configBody).toContain('version: 1');
     expect(configBody).toContain('skillPaths: []');
   });
 
   it('should be idempotent and keep existing config values on re-run', async () => {
-    const homeDir = mkdtempSync(join(tmpdir(), 'faceted-home-'));
-    tempDirs.push(homeDir);
+    const cwd = mkdtempSync(join(tmpdir(), 'faceted-workspace-'));
+    tempDirs.push(cwd);
 
-    const { initializeFacetedHome } = await loadInitModule();
-    await initializeFacetedHome({ homeDir });
+    const { initializeLocalFaceted } = await loadInitModule();
+    await initializeLocalFaceted({ cwd });
 
-    const configPath = join(homeDir, '.faceted', 'config.yaml');
+    const configPath = join(cwd, '.faceted', 'config.yaml');
     const customConfig = [
       'version: 1',
       'skillPaths:',
@@ -103,25 +102,85 @@ describe('initializeFacetedHome', () => {
     ].join('\n');
     rmSync(configPath, { force: true });
     writeFileSync(configPath, customConfig, 'utf-8');
-    await initializeFacetedHome({ homeDir });
+
+    await initializeLocalFaceted({ cwd });
+
     expect(readFileSync(configPath, 'utf-8')).toContain('/tmp/custom-skill');
-    expect(existsSync(join(homeDir, '.faceted', 'templates'))).toBe(true);
+    expect(existsSync(join(cwd, '.faceted', 'templates'))).toBe(true);
   });
 
   it('should not overwrite existing templates on re-run', async () => {
-    const homeDir = mkdtempSync(join(tmpdir(), 'faceted-home-'));
-    tempDirs.push(homeDir);
+    const cwd = mkdtempSync(join(tmpdir(), 'faceted-workspace-'));
+    tempDirs.push(cwd);
 
-    const { initializeFacetedHome } = await loadInitModule();
-    await initializeFacetedHome({ homeDir });
+    const { initializeLocalFaceted } = await loadInitModule();
+    await initializeLocalFaceted({ cwd });
 
-    const personaTemplatePath = join(homeDir, '.faceted', 'templates', 'custom', 'SKILL.md');
+    const personaTemplatePath = join(cwd, '.faceted', 'templates', 'custom', 'SKILL.md');
     mkdirSync(dirname(personaTemplatePath), { recursive: true });
     const customPersonaTemplate = 'Custom persona template';
     writeFileSync(personaTemplatePath, customPersonaTemplate, 'utf-8');
 
-    await initializeFacetedHome({ homeDir });
+    await initializeLocalFaceted({ cwd });
+
     expect(readFileSync(personaTemplatePath, 'utf-8')).toBe(customPersonaTemplate);
+  });
+});
+
+describe('initializeGlobalFaceted', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('should initialize global faceted home and pull sample facets', async () => {
+    const homeDir = mkdtempSync(join(tmpdir(), 'faceted-home-'));
+    tempDirs.push(homeDir);
+    const fetchUrls: string[] = [];
+    const responses = new Map<string, string>([
+      ['personas/coder.md', '# Remote Coder\n'],
+      ['knowledge/architecture.md', '# Remote Architecture\n'],
+      ['knowledge/frontend.md', '# Remote Frontend\n'],
+      ['knowledge/backend.md', '# Remote Backend\n'],
+      ['policies/coding.md', '# Remote Coding\n'],
+      ['policies/ai-antipattern.md', '# Remote AI Antipattern\n'],
+    ]);
+
+    const { initializeGlobalFaceted } = await loadInitModule();
+    await initializeGlobalFaceted({
+      homeDir,
+      fetchImpl: async input => {
+        fetchUrls.push(input);
+        const key = input.replace('https://raw.githubusercontent.com/nrslib/takt/main/builtins/ja/facets/', '');
+        const body = responses.get(key);
+        if (!body) {
+          return {
+            ok: false,
+            status: 404,
+            text: async () => '',
+          };
+        }
+        return {
+          ok: true,
+          status: 200,
+          text: async () => body,
+        };
+      },
+    });
+
+    expect(fetchUrls).toHaveLength(6);
+    expect(existsSync(join(homeDir, '.faceted', 'config.yaml'))).toBe(true);
+    expect(readFileSync(join(homeDir, '.faceted', 'facets', 'persona', 'coder.md'), 'utf-8')).toBe('# Remote Coder\n');
+    expect(readFileSync(join(homeDir, '.faceted', 'facets', 'knowledge', 'architecture.md'), 'utf-8')).toBe(
+      '# Remote Architecture\n',
+    );
+    expect(readFileSync(join(homeDir, '.faceted', 'compositions', 'coding.yaml'), 'utf-8')).toContain('name: coding');
+    expect(readFileSync(join(homeDir, '.faceted', 'templates', 'issue-worktree', 'SKILL.md'), 'utf-8')).toContain(
+      '{{facet:persona}}',
+    );
   });
 });
 
@@ -138,9 +197,7 @@ describe('pullSampleFacets', () => {
     const homeDir = mkdtempSync(join(tmpdir(), 'faceted-home-'));
     tempDirs.push(homeDir);
 
-    const { initializeFacetedHome, pullSampleFacets } = await loadInitModule();
-    await initializeFacetedHome({ homeDir });
-
+    const { pullSampleFacets } = await loadInitModule();
     const fetchUrls: string[] = [];
     const responses = new Map<string, string>([
       ['personas/coder.md', '# Remote Coder\n'],
@@ -189,10 +246,9 @@ describe('pullSampleFacets', () => {
     const homeDir = mkdtempSync(join(tmpdir(), 'faceted-home-'));
     tempDirs.push(homeDir);
 
-    const { initializeFacetedHome, pullSampleFacets } = await loadInitModule();
-    await initializeFacetedHome({ homeDir });
-
+    const { pullSampleFacets } = await loadInitModule();
     const coderPath = join(homeDir, '.faceted', 'facets', 'persona', 'coder.md');
+    mkdirSync(dirname(coderPath), { recursive: true });
     writeFileSync(coderPath, '# Custom Coder\n', 'utf-8');
 
     const fetchUrls: string[] = [];
@@ -217,10 +273,9 @@ describe('pullSampleFacets', () => {
     const homeDir = mkdtempSync(join(tmpdir(), 'faceted-home-'));
     tempDirs.push(homeDir);
 
-    const { initializeFacetedHome, pullSampleFacets } = await loadInitModule();
-    await initializeFacetedHome({ homeDir });
-
+    const { pullSampleFacets } = await loadInitModule();
     const coderPath = join(homeDir, '.faceted', 'facets', 'persona', 'coder.md');
+    mkdirSync(dirname(coderPath), { recursive: true });
     writeFileSync(coderPath, '# Custom Coder\n', 'utf-8');
 
     await pullSampleFacets({

--- a/src/__tests__/it-cli-compose-flow.test.ts
+++ b/src/__tests__/it-cli-compose-flow.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process';
 import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
@@ -32,6 +33,8 @@ async function runInit(runFacetCli: CliModule['runFacetCli'], workspaceDir: stri
 }
 
 function writeDefaultFacetFixture(homeDir: string, persona = 'You are a coding agent.\n'): void {
+  mkdirSync(join(homeDir, '.faceted'), { recursive: true });
+  writeFileSync(join(homeDir, '.faceted', 'config.yaml'), 'version: 1\n', 'utf-8');
   const facetsRoot = join(homeDir, '.faceted', 'facets');
   mkdirSync(join(facetsRoot, 'persona'), { recursive: true });
   mkdirSync(join(facetsRoot, 'knowledge'), { recursive: true });
@@ -42,6 +45,30 @@ function writeDefaultFacetFixture(homeDir: string, persona = 'You are a coding a
   writeFileSync(join(facetsRoot, 'knowledge', 'backend.md'), 'Backend reference.\n', 'utf-8');
   writeFileSync(join(facetsRoot, 'policies', 'coding.md'), 'Never hide errors.\n', 'utf-8');
   writeFileSync(join(facetsRoot, 'policies', 'ai-antipattern.md'), 'Do not add dead code.\n', 'utf-8');
+}
+
+function writeFacetFilesUnderFacetedRoot(
+  facetedRoot: string,
+  contents: {
+    persona: string;
+    codingPolicy: string;
+    aiAntipatternPolicy: string;
+    architecture: string;
+    frontend: string;
+    backend: string;
+  },
+): void {
+  const facetsRoot = join(facetedRoot, 'facets');
+  mkdirSync(join(facetsRoot, 'persona'), { recursive: true });
+  mkdirSync(join(facetsRoot, 'knowledge'), { recursive: true });
+  mkdirSync(join(facetsRoot, 'policies'), { recursive: true });
+  writeFileSync(join(facetedRoot, 'config.yaml'), 'version: 1\n', 'utf-8');
+  writeFileSync(join(facetsRoot, 'persona', 'coder.md'), contents.persona, 'utf-8');
+  writeFileSync(join(facetsRoot, 'knowledge', 'architecture.md'), contents.architecture, 'utf-8');
+  writeFileSync(join(facetsRoot, 'knowledge', 'frontend.md'), contents.frontend, 'utf-8');
+  writeFileSync(join(facetsRoot, 'knowledge', 'backend.md'), contents.backend, 'utf-8');
+  writeFileSync(join(facetsRoot, 'policies', 'coding.md'), contents.codingPolicy, 'utf-8');
+  writeFileSync(join(facetsRoot, 'policies', 'ai-antipattern.md'), contents.aiAntipatternPolicy, 'utf-8');
 }
 
 describe('facet compose integration flow', () => {
@@ -111,6 +138,81 @@ describe('facet compose integration flow', () => {
     expect(generated).toContain('Source: src/App.tsx');
   });
 
+  it('should prefer local facets and fallback to global facets when local facets are missing', async () => {
+    const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-workspace-'));
+    const homeDir = mkdtempSync(join(tmpdir(), 'facet-home-'));
+    tempDirs.push(workspaceDir, homeDir);
+
+    writeFileSync(join(workspaceDir, 'server.ts'), 'export const server = true;\n', 'utf-8');
+    writeFacetFilesUnderFacetedRoot(join(homeDir, '.faceted'), {
+      persona: 'You are a global coder persona.\n',
+      codingPolicy: 'Global coding policy.\n',
+      aiAntipatternPolicy: 'Global AI antipattern policy.\n',
+      architecture: 'Global architecture knowledge.\n',
+      frontend: 'Global frontend knowledge.\n',
+      backend: 'Global backend knowledge.\n',
+    });
+
+    const localFacetedRoot = join(workspaceDir, '.faceted');
+    mkdirSync(join(localFacetedRoot, 'facets', 'persona'), { recursive: true });
+    mkdirSync(join(localFacetedRoot, 'facets', 'policies'), { recursive: true });
+    writeFileSync(join(localFacetedRoot, 'facets', 'persona', 'coder.md'), 'You are a local coder persona.\n', 'utf-8');
+    writeFileSync(join(localFacetedRoot, 'facets', 'policies', 'coding.md'), 'Local coding policy.\n', 'utf-8');
+
+    const { runFacetCli } = await loadCliModule();
+    const result = await runFacetCli(['compose'], {
+      cwd: workspaceDir,
+      homeDir,
+      select: async () => 'Combined (single file)',
+      input: async (_prompt, defaultValue) => defaultValue,
+    });
+
+    expect(result.kind).toBe('path');
+    if (result.kind !== 'path') {
+      throw new Error('Expected path result for compose command');
+    }
+
+    const generated = readFileSync(result.path, 'utf-8');
+    expect(generated).toContain('You are a local coder persona.');
+    expect(generated).toContain('Local coding policy.');
+    expect(generated).toContain('Global AI antipattern policy.');
+    expect(generated).toContain('Global architecture knowledge.');
+  });
+
+  it('should compose with local facets when global faceted home is not initialized', async () => {
+    const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-workspace-'));
+    const homeDir = mkdtempSync(join(tmpdir(), 'facet-home-'));
+    tempDirs.push(workspaceDir, homeDir);
+
+    writeFileSync(join(workspaceDir, 'api.ts'), 'export const api = true;\n', 'utf-8');
+    writeFacetFilesUnderFacetedRoot(join(workspaceDir, '.faceted'), {
+      persona: 'You are a local-only coder persona.\n',
+      codingPolicy: 'Local-only coding policy.\n',
+      aiAntipatternPolicy: 'Local-only AI antipattern policy.\n',
+      architecture: 'Local-only architecture knowledge.\n',
+      frontend: 'Local-only frontend knowledge.\n',
+      backend: 'Local-only backend knowledge.\n',
+    });
+
+    const { runFacetCli } = await loadCliModule();
+    const result = await runFacetCli(['compose'], {
+      cwd: workspaceDir,
+      homeDir,
+      select: async () => 'Combined (single file)',
+      input: async (_prompt, defaultValue) => defaultValue,
+    });
+
+    expect(result.kind).toBe('path');
+    if (result.kind !== 'path') {
+      throw new Error('Expected path result for compose command');
+    }
+
+    const generated = readFileSync(result.path, 'utf-8');
+    expect(generated).toContain('You are a local-only coder persona.');
+    expect(generated).toContain('Local-only coding policy.');
+    expect(generated).toContain('Local-only architecture knowledge.');
+  });
+
   it('should reject unsupported commands', async () => {
     const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-workspace-'));
     const homeDir = mkdtempSync(join(tmpdir(), 'facet-home-'));
@@ -139,23 +241,39 @@ describe('facet compose integration flow', () => {
     })).rejects.toThrow('Usage: facet <command>');
   });
 
-  it('should fail compose command when config file is malformed', async () => {
+  it('should compose with local facets even when global config file is malformed', async () => {
     const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-workspace-'));
     const homeDir = mkdtempSync(join(tmpdir(), 'facet-home-'));
     tempDirs.push(workspaceDir, homeDir);
 
-    const facetedRoot = join(homeDir, '.faceted');
-    mkdirSync(facetedRoot, { recursive: true });
-    const configPath = join(facetedRoot, 'config.yaml');
-    writeFileSync(configPath, 'version: [1\n', 'utf-8');
+    const globalFacetedRoot = join(homeDir, '.faceted');
+    mkdirSync(globalFacetedRoot, { recursive: true });
+    writeFileSync(join(globalFacetedRoot, 'config.yaml'), 'version: [1\n', 'utf-8');
+    writeFileSync(join(workspaceDir, 'service.ts'), 'export const service = true;\n', 'utf-8');
+    writeFacetFilesUnderFacetedRoot(join(workspaceDir, '.faceted'), {
+      persona: 'You are a local malformed-config fallback persona.\n',
+      codingPolicy: 'Local malformed-config coding policy.\n',
+      aiAntipatternPolicy: 'Local malformed-config AI policy.\n',
+      architecture: 'Local malformed-config architecture knowledge.\n',
+      frontend: 'Local malformed-config frontend knowledge.\n',
+      backend: 'Local malformed-config backend knowledge.\n',
+    });
 
     const { runFacetCli } = await loadCliModule();
-    await expect(runFacetCli(['compose'], {
+    const result = await runFacetCli(['compose'], {
       cwd: workspaceDir,
       homeDir,
-      select: async () => 'unused',
+      select: async () => 'Combined (single file)',
       input: async (_prompt, defaultValue) => defaultValue,
-    })).rejects.toThrow(`Invalid faceted config file: ${configPath}`);
+    });
+
+    expect(result.kind).toBe('path');
+    if (result.kind !== 'path') {
+      throw new Error('Expected path result for compose command');
+    }
+    const generated = readFileSync(result.path, 'utf-8');
+    expect(generated).toContain('You are a local malformed-config fallback persona.');
+    expect(generated).toContain('Local malformed-config coding policy.');
   });
 
   it('should compose after init when required facets are prepared', async () => {
@@ -173,7 +291,7 @@ describe('facet compose integration flow', () => {
 
     expect(initResult).toEqual({
       kind: 'text',
-      text: `Initialized: ${join(homeDir, '.faceted')}`,
+      text: `Initialized: ${join(workspaceDir, '.faceted')}`,
     });
 
     writeDefaultFacetFixture(homeDir, 'You are a prepared coding assistant.\n');
@@ -217,7 +335,7 @@ describe('facet compose integration flow', () => {
       homeDir,
       select: async () => 'unused',
       input: async (_prompt, defaultValue) => defaultValue,
-    })).rejects.toThrow(`Missing faceted config: ${join(homeDir, '.faceted', 'config.yaml')}`);
+    })).rejects.toThrow('Missing persona facet "coder"');
   });
 
   it('should truncate related file content and keep source reference', async () => {
@@ -245,6 +363,41 @@ describe('facet compose integration flow', () => {
     const generated = readFileSync(result.path, 'utf-8');
     expect(generated).toContain('...TRUNCATED...');
     expect(generated).toContain('Source: long.ts');
+  });
+
+  it('should include only cwd-scoped git files in related files when composing from a subdirectory', async () => {
+    const repositoryDir = mkdtempSync(join(tmpdir(), 'facet-repo-'));
+    const workspaceDir = join(repositoryDir, 'workspace');
+    const homeDir = mkdtempSync(join(tmpdir(), 'facet-home-'));
+    tempDirs.push(repositoryDir, homeDir);
+    mkdirSync(workspaceDir, { recursive: true });
+
+    execFileSync('git', ['init'], { cwd: repositoryDir, stdio: 'pipe' });
+
+    const { runFacetCli } = await loadCliModule();
+    await runInit(runFacetCli, workspaceDir, homeDir);
+    writeDefaultFacetFixture(homeDir);
+    execFileSync('git', ['add', '.'], { cwd: repositoryDir, stdio: 'pipe' });
+
+    mkdirSync(join(workspaceDir, 'src'), { recursive: true });
+    writeFileSync(join(workspaceDir, 'src', 'App.tsx'), 'export const App = () => <div>ok</div>;\n', 'utf-8');
+    writeFileSync(join(repositoryDir, 'outside.ts'), 'export const outside = true;\n', 'utf-8');
+
+    const result = await runFacetCli(['compose'], {
+      cwd: workspaceDir,
+      homeDir,
+      select: async () => 'Combined (single file)',
+      input: async (_prompt, defaultValue) => defaultValue,
+    });
+
+    expect(result.kind).toBe('path');
+    if (result.kind !== 'path') {
+      throw new Error('Expected path result for compose command');
+    }
+
+    const generated = readFileSync(result.path, 'utf-8');
+    expect(generated).toContain('Source: src/App.tsx');
+    expect(generated).not.toContain('outside.ts');
   });
 
   it('should cancel overwrite when output file exists and answer is not y/yes', async () => {

--- a/src/__tests__/it-cli-facet-modes.test.ts
+++ b/src/__tests__/it-cli-facet-modes.test.ts
@@ -125,7 +125,7 @@ describe('facet install template-backed skill integration flow', () => {
     const result = await runFacetCli(['install', 'skill'], {
       cwd: workspaceDir,
       homeDir,
-      select: createSelectStub(['templated', 'Codex']),
+      select: createSelectStub(['templated (global)', 'Codex']),
       input: async (_prompt, defaultValue) => defaultValue,
     });
 
@@ -155,7 +155,7 @@ describe('facet install template-backed skill integration flow', () => {
     await expect(runFacetCli(['install', 'skill'], {
       cwd: workspaceDir,
       homeDir,
-      select: createSelectStub(['templated', 'Codex']),
+      select: createSelectStub(['templated (global)', 'Codex']),
       input: async (prompt, defaultValue) => {
         if (prompt.toLowerCase().includes('replace') || prompt.toLowerCase().includes('overwrite')) {
           return 'n';
@@ -181,9 +181,27 @@ describe('facet install template-backed skill integration flow', () => {
     await expect(runFacetCli(['install', 'skill'], {
       cwd: workspaceDir,
       homeDir,
-      select: createSelectStub(['templated', 'Codex']),
+      select: createSelectStub(['templated (global)', 'Codex']),
       input: async (_prompt, defaultValue) => defaultValue,
     })).rejects.toThrow(`Symbolic links are not allowed in Target directory path: ${codexLinkDir}`);
+  });
+
+  it('should reject template-backed install when output path is outside selected target directory', async () => {
+    const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-workspace-'));
+    const homeDir = mkdtempSync(join(tmpdir(), 'facet-home-'));
+    tempDirs.push(workspaceDir, homeDir);
+    createFacetedFixture(homeDir);
+
+    const disallowedOutputPath = join(homeDir, 'SKILL.md');
+    const { runFacetCli } = await loadCliModule();
+
+    await expect(runFacetCli(['install', 'skill'], {
+      cwd: workspaceDir,
+      homeDir,
+      select: createSelectStub(['templated (global)', 'Codex']),
+      input: async (prompt, defaultValue) =>
+        prompt.toLowerCase().includes('output') ? disallowedOutputPath : defaultValue,
+    })).rejects.toThrow(`Skill output path must be inside target directory: ${join(homeDir, '.codex', 'skills')}`);
   });
 
   it('should install template-backed skill even when composition has no instruction', async () => {
@@ -198,7 +216,7 @@ describe('facet install template-backed skill integration flow', () => {
     const result = await runFacetCli(['install', 'skill'], {
       cwd: workspaceDir,
       homeDir,
-      select: createSelectStub(['templated-no-instruction', 'Codex']),
+      select: createSelectStub(['templated-no-instruction (global)', 'Codex']),
       input: async (_prompt, defaultValue) => defaultValue,
     });
 
@@ -206,5 +224,44 @@ describe('facet install template-backed skill integration flow', () => {
     expect(readFileSync(skillOutputPath, 'utf-8')).toMatch(/^---\nname: templated-no-instruction-skill\n---\n/m);
     expect(readFileSync(skillOutputPath, 'utf-8')).toContain('instructions=');
     expect(readFileSync(skillOutputPath, 'utf-8')).not.toContain('{{facet:instructions}}');
+  });
+
+  it('should fallback to global template when local composition references missing template', async () => {
+    const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-workspace-'));
+    const homeDir = mkdtempSync(join(tmpdir(), 'facet-home-'));
+    tempDirs.push(workspaceDir, homeDir);
+    createFacetedFixture(homeDir);
+
+    const localFacetedRoot = join(workspaceDir, '.faceted');
+    mkdirSync(join(localFacetedRoot, 'facets', 'persona'), { recursive: true });
+    mkdirSync(join(localFacetedRoot, 'compositions'), { recursive: true });
+    writeFileSync(join(localFacetedRoot, 'facets', 'persona', 'local-coder.md'), 'Local persona', 'utf-8');
+    writeFileSync(
+      join(localFacetedRoot, 'compositions', 'templated.yaml'),
+      [
+        'name: templated-skill',
+        'persona: local-coder',
+        'knowledge:',
+        '  - architecture',
+        'policies:',
+        '  - coding',
+        'template: starter-kit',
+      ].join('\n'),
+      'utf-8',
+    );
+
+    const skillOutputPath = join(homeDir, '.codex', 'skills', 'templated-skill', 'SKILL.md');
+    const { runFacetCli } = await loadCliModule();
+    const result = await runFacetCli(['install', 'skill'], {
+      cwd: workspaceDir,
+      homeDir,
+      select: createSelectStub(['templated (local)', 'Codex']),
+      input: async (prompt, defaultValue) =>
+        prompt.includes('overrides global definition') ? 'y' : defaultValue,
+    });
+
+    expect(result).toEqual({ kind: 'path', path: skillOutputPath });
+    expect(readFileSync(skillOutputPath, 'utf-8')).toContain('Local persona');
+    expect(existsSync(join(homeDir, '.codex', 'skills', 'templated-skill', 'README.md'))).toBe(true);
   });
 });

--- a/src/__tests__/it-cli-setup-flow.test.ts
+++ b/src/__tests__/it-cli-setup-flow.test.ts
@@ -33,7 +33,7 @@ describe('facet init/pull-sample integration flow', () => {
     }
   });
 
-  it('should initialize faceted home via init command', async () => {
+  it('should initialize local faceted directory via init command', async () => {
     const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-workspace-'));
     const homeDir = mkdtempSync(join(tmpdir(), 'facet-home-'));
     tempDirs.push(workspaceDir, homeDir);
@@ -48,11 +48,54 @@ describe('facet init/pull-sample integration flow', () => {
 
     expect(result).toEqual({
       kind: 'text',
-      text: `Initialized: ${join(homeDir, '.faceted')}`,
+      text: `Initialized: ${join(workspaceDir, '.faceted')}`,
     });
-    expect(existsSync(join(homeDir, '.faceted', 'config.yaml'))).toBe(true);
-    expect(existsSync(join(homeDir, '.faceted', 'compositions', 'coding.yaml'))).toBe(false);
-    expect(existsSync(join(homeDir, '.faceted', 'facets', 'persona', 'coder.md'))).toBe(false);
+    expect(existsSync(join(workspaceDir, '.faceted', 'config.yaml'))).toBe(true);
+    expect(existsSync(join(homeDir, '.faceted', 'config.yaml'))).toBe(false);
+    expect(existsSync(join(workspaceDir, '.faceted', 'compositions', 'coding.yaml'))).toBe(false);
+    expect(existsSync(join(workspaceDir, '.faceted', 'facets', 'persona', 'coder.md'))).toBe(false);
+  });
+
+  it('should initialize global faceted home and pull sample facets via init global command', async () => {
+    const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-workspace-'));
+    const homeDir = mkdtempSync(join(tmpdir(), 'facet-home-'));
+    tempDirs.push(workspaceDir, homeDir);
+
+    const { runFacetCli } = await loadCliModule();
+    globalThis.fetch = (async (input: string | URL) => {
+      const url = input.toString();
+      const key = url.replace('https://raw.githubusercontent.com/nrslib/takt/main/builtins/ja/facets/', '');
+      const responses = new Map<string, string>([
+        ['personas/coder.md', '# Pulled Coder\n'],
+        ['knowledge/architecture.md', '# Pulled Architecture\n'],
+        ['knowledge/frontend.md', '# Pulled Frontend\n'],
+        ['knowledge/backend.md', '# Pulled Backend\n'],
+        ['policies/coding.md', '# Pulled Coding\n'],
+        ['policies/ai-antipattern.md', '# Pulled AI Antipattern\n'],
+      ]);
+      const body = responses.get(key);
+      if (!body) {
+        return new Response('', { status: 404 });
+      }
+      return new Response(body, { status: 200 });
+    }) as typeof fetch;
+
+    const result = await runFacetCli(['init', 'global'], {
+      cwd: workspaceDir,
+      homeDir,
+      select: async () => 'unused',
+      input: async (_prompt, defaultValue) => defaultValue,
+    });
+
+    expect(result.kind).toBe('text');
+    if (result.kind !== 'text') {
+      throw new Error('Expected text result for init global');
+    }
+    expect(result.text).toContain(join(homeDir, '.faceted'));
+    expect(result.text.toLowerCase()).toContain('sample');
+    expect(existsSync(join(homeDir, '.faceted', 'compositions', 'coding.yaml'))).toBe(true);
+    expect(readFileSync(join(homeDir, '.faceted', 'facets', 'persona', 'coder.md'), 'utf-8')).toBe('# Pulled Coder\n');
+    expect(readFileSync(join(homeDir, '.faceted', 'compositions', 'coding.yaml'), 'utf-8')).toContain('name: coding');
   });
 
   it('should fetch TAKT sample facets via pull-sample command', async () => {
@@ -103,7 +146,7 @@ describe('facet init/pull-sample integration flow', () => {
     tempDirs.push(workspaceDir, homeDir);
 
     const { runFacetCli } = await loadCliModule();
-    await runFacetCli(['init'], {
+    await runFacetCli(['init', 'global'], {
       cwd: workspaceDir,
       homeDir,
       select: async () => 'unused',
@@ -142,5 +185,19 @@ describe('facet init/pull-sample integration flow', () => {
       text: `Pulled sample: ${join(homeDir, '.faceted')}`,
     });
     expect(readFileSync(personaPath, 'utf-8')).toBe('# Overwritten Persona\n');
+  });
+
+  it('should reject unknown init subcommand', async () => {
+    const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-workspace-'));
+    const homeDir = mkdtempSync(join(tmpdir(), 'facet-home-'));
+    tempDirs.push(workspaceDir, homeDir);
+
+    const { runFacetCli } = await loadCliModule();
+    await expect(runFacetCli(['init', 'unknown'], {
+      cwd: workspaceDir,
+      homeDir,
+      select: async () => 'unused',
+      input: async (_prompt, defaultValue) => defaultValue,
+    })).rejects.toThrow('Unsupported command: init unknown');
   });
 });

--- a/src/__tests__/it-cli-skill-flow.test.ts
+++ b/src/__tests__/it-cli-skill-flow.test.ts
@@ -35,10 +35,15 @@ async function runInit(runFacetCli: CliModule['runFacetCli'], workspaceDir: stri
   });
 }
 
-function createFacetedFixture(homeDir: string): {
+function writeGlobalConfig(homeDir: string): void {
+  const facetedRoot = join(homeDir, '.faceted');
+  mkdirSync(facetedRoot, { recursive: true });
+  writeFileSync(join(facetedRoot, 'config.yaml'), 'version: 1\n', 'utf-8');
+}
+
+function createFacetedFixtureAtRoot(facetedRoot: string): {
   compositionsRoot: string;
 } {
-  const facetedRoot = join(homeDir, '.faceted');
   const facetsRoot = join(facetedRoot, 'facets');
   const compositionsRoot = join(facetedRoot, 'compositions');
 
@@ -66,6 +71,12 @@ function createFacetedFixture(homeDir: string): {
   );
 
   return { compositionsRoot };
+}
+
+function createFacetedFixture(homeDir: string): {
+  compositionsRoot: string;
+} {
+  return createFacetedFixtureAtRoot(join(homeDir, '.faceted'));
 }
 
 function createSelectStub(expectedSelections: readonly string[]) {
@@ -103,7 +114,7 @@ describe('facet skill integration flow', () => {
     const result = await runFacetCli(['install', 'skill'], {
       cwd: workspaceDir,
       homeDir,
-      select: createSelectStub(['coding', 'Claude Code']),
+      select: createSelectStub(['coding (global)', 'Claude Code']),
       input: async (prompt, defaultValue) =>
         prompt.toLowerCase().includes('output') ? skillOutputPath : defaultValue,
     });
@@ -111,6 +122,52 @@ describe('facet skill integration flow', () => {
     expect(result).toEqual({ kind: 'path', path: skillOutputPath });
     expect(existsSync(skillOutputPath)).toBe(true);
     expect(readFileSync(skillOutputPath, 'utf-8')).toContain('You are a coding agent.');
+  });
+
+  it('should prefer local composition and facets while falling back to global facets for missing refs', async () => {
+    const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-workspace-'));
+    const homeDir = mkdtempSync(join(tmpdir(), 'facet-home-'));
+    tempDirs.push(workspaceDir, homeDir);
+
+    createFacetedFixture(homeDir);
+
+    const localFacetedRoot = join(workspaceDir, '.faceted');
+    mkdirSync(join(localFacetedRoot, 'facets', 'persona'), { recursive: true });
+    mkdirSync(join(localFacetedRoot, 'compositions'), { recursive: true });
+    writeFileSync(
+      join(localFacetedRoot, 'compositions', 'coding.yaml'),
+      [
+        'name: coding',
+        'description: Local coding workflow',
+        'persona: local-coder',
+        'policies:',
+        '  - coding',
+        'knowledge:',
+        '  - architecture',
+      ].join('\n'),
+      'utf-8',
+    );
+    writeFileSync(
+      join(localFacetedRoot, 'facets', 'persona', 'local-coder.md'),
+      'You are a local coding agent.',
+      'utf-8',
+    );
+
+    const defaultSkillOutputPath = join(homeDir, '.codex', 'skills', 'coding', 'SKILL.md');
+    const { runFacetCli } = await loadCliModule();
+    const result = await runFacetCli(['install', 'skill'], {
+      cwd: workspaceDir,
+      homeDir,
+      select: createSelectStub(['coding (local)', 'Codex']),
+      input: async (prompt, defaultValue) =>
+        prompt.includes('overrides global definition') ? 'y' : defaultValue,
+    });
+
+    expect(result).toEqual({ kind: 'path', path: defaultSkillOutputPath });
+    const skillBody = readFileSync(defaultSkillOutputPath, 'utf-8');
+    expect(skillBody).toContain('You are a local coding agent.');
+    expect(skillBody).toContain('Never hide errors.');
+    expect(skillBody).toContain('Architecture reference.');
   });
 
   it('should require init before install skill', async () => {
@@ -124,7 +181,30 @@ describe('facet skill integration flow', () => {
       homeDir,
       select: async () => 'unused',
       input: async (_prompt, defaultValue) => defaultValue,
-    })).rejects.toThrow(`Missing faceted config: ${join(homeDir, '.faceted', 'config.yaml')}`);
+    })).rejects.toThrow(`No compose definitions found in ${join(homeDir, '.faceted', 'compositions')}`);
+  });
+
+  it('should install skill using local faceted root when global faceted home is not initialized', async () => {
+    const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-workspace-'));
+    const homeDir = mkdtempSync(join(tmpdir(), 'facet-home-'));
+    tempDirs.push(workspaceDir, homeDir);
+
+    createFacetedFixtureAtRoot(join(workspaceDir, '.faceted'));
+
+    const defaultSkillOutputPath = join(homeDir, '.claude', 'skills', 'coding', 'SKILL.md');
+    const { runFacetCli } = await loadCliModule();
+
+    const result = await runFacetCli(['install', 'skill'], {
+      cwd: workspaceDir,
+      homeDir,
+      select: createSelectStub(['coding (local)', 'Claude Code']),
+      input: async (_prompt, defaultValue) => defaultValue,
+    });
+
+    expect(result).toEqual({ kind: 'path', path: defaultSkillOutputPath });
+    expect(existsSync(defaultSkillOutputPath)).toBe(true);
+    expect(readFileSync(defaultSkillOutputPath, 'utf-8')).toContain('You are a coding agent.');
+    expect(readFileSync(defaultSkillOutputPath, 'utf-8')).toContain('Never hide errors.');
   });
 
   it('should not offer compositions immediately after init', async () => {
@@ -134,13 +214,16 @@ describe('facet skill integration flow', () => {
 
     const { runFacetCli } = await loadCliModule();
     await runInit(runFacetCli, workspaceDir, homeDir);
+    writeGlobalConfig(homeDir);
 
     await expect(runFacetCli(['install', 'skill'], {
       cwd: workspaceDir,
       homeDir,
       select: async () => 'unused',
       input: async (_prompt, defaultValue) => defaultValue,
-    })).rejects.toThrow(`No compose definitions found in ${join(homeDir, '.faceted', 'compositions')}`);
+    })).rejects.toThrow(
+      `No compose definitions found in ${join(workspaceDir, '.faceted', 'compositions')}, ${join(homeDir, '.faceted', 'compositions')}`,
+    );
   });
 
   it('should install skill to default Claude Code output path when default input is accepted', async () => {
@@ -155,7 +238,7 @@ describe('facet skill integration flow', () => {
     const result = await runFacetCli(['install', 'skill'], {
       cwd: workspaceDir,
       homeDir,
-      select: createSelectStub(['coding', 'Claude Code']),
+      select: createSelectStub(['coding (global)', 'Claude Code']),
       input: async (_prompt, defaultValue) => defaultValue,
     });
 
@@ -175,7 +258,7 @@ describe('facet skill integration flow', () => {
     let selectCallCount = 0;
     const select = async (candidates: string[]): Promise<string> => {
       selectCallCount += 1;
-      if (selectCallCount === 1) return 'coding';
+      if (selectCallCount === 1) return 'coding (global)';
       if (selectCallCount === 2) {
         expect(candidates).toEqual(['Claude Code', 'Codex']);
         return 'Claude Code';
@@ -204,7 +287,7 @@ describe('facet skill integration flow', () => {
     const result = await runFacetCli(['install', 'skill'], {
       cwd: workspaceDir,
       homeDir,
-      select: createSelectStub(['coding', 'Codex']),
+      select: createSelectStub(['coding (global)', 'Codex']),
       input: async (_prompt, defaultValue) => defaultValue,
     });
 
@@ -236,8 +319,13 @@ describe('facet skill integration flow', () => {
       select: async (candidates: string[]): Promise<string> => {
         selectCallCount += 1;
         if (selectCallCount === 1) {
-          expect(candidates).toEqual(['backend', 'coding', 'frontend', 'issue-worktree']);
-          return 'issue-worktree';
+          expect(candidates).toEqual([
+            'backend (global)',
+            'coding (global)',
+            'frontend (global)',
+            'issue-worktree (global)',
+          ]);
+          return 'issue-worktree (global)';
         }
         if (selectCallCount === 2) {
           expect(candidates).toEqual(['Claude Code', 'Codex']);
@@ -269,7 +357,7 @@ describe('facet skill integration flow', () => {
     await expect(runFacetCli(['install', 'skill'], {
       cwd: workspaceDir,
       homeDir,
-      select: createSelectStub(['unsafe', 'Claude Code']),
+      select: createSelectStub(['unsafe (global)', 'Claude Code']),
       input: async (_prompt, defaultValue) => defaultValue,
     })).rejects.toThrow('Invalid compose definition name: ../unsafe');
   });
@@ -285,10 +373,46 @@ describe('facet skill integration flow', () => {
     await expect(runFacetCli(['install', 'skill'], {
       cwd: workspaceDir,
       homeDir,
-      select: createSelectStub(['coding', 'Claude Code']),
+      select: createSelectStub(['coding (global)', 'Claude Code']),
       input: async (prompt, defaultValue) =>
         prompt.toLowerCase().includes('output') ? outsidePath : defaultValue,
     })).rejects.toThrow(`Skill output path must be inside home directory: ${outsidePath}`);
+  });
+
+  it('should reject install when output path points to target root SKILL.md', async () => {
+    const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-workspace-'));
+    const homeDir = mkdtempSync(join(tmpdir(), 'facet-home-'));
+    tempDirs.push(workspaceDir, homeDir);
+    createFacetedFixture(homeDir);
+
+    const targetRootOutputPath = join(homeDir, '.claude', 'skills', 'SKILL.md');
+    const { runFacetCli } = await loadCliModule();
+    await expect(runFacetCli(['install', 'skill'], {
+      cwd: workspaceDir,
+      homeDir,
+      select: createSelectStub(['coding (global)', 'Claude Code']),
+      input: async (prompt, defaultValue) =>
+        prompt.toLowerCase().includes('output') ? targetRootOutputPath : defaultValue,
+    })).rejects.toThrow(
+      `Skill output path must include a skill directory under target directory: ${join(homeDir, '.claude', 'skills')}`,
+    );
+  });
+
+  it('should reject install when output path file name is not SKILL.md', async () => {
+    const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-workspace-'));
+    const homeDir = mkdtempSync(join(tmpdir(), 'facet-home-'));
+    tempDirs.push(workspaceDir, homeDir);
+    createFacetedFixture(homeDir);
+
+    const invalidFileNamePath = join(homeDir, '.claude', 'skills', 'coding', 'custom.md');
+    const { runFacetCli } = await loadCliModule();
+    await expect(runFacetCli(['install', 'skill'], {
+      cwd: workspaceDir,
+      homeDir,
+      select: createSelectStub(['coding (global)', 'Claude Code']),
+      input: async (prompt, defaultValue) =>
+        prompt.toLowerCase().includes('output') ? invalidFileNamePath : defaultValue,
+    })).rejects.toThrow(`Skill output path must point to SKILL.md: ${invalidFileNamePath}`);
   });
 
   it('should reject install when skill output path points to a symbolic link', async () => {
@@ -307,10 +431,35 @@ describe('facet skill integration flow', () => {
     await expect(runFacetCli(['install', 'skill'], {
       cwd: workspaceDir,
       homeDir,
-      select: createSelectStub(['coding', 'Claude Code']),
+      select: createSelectStub(['coding (global)', 'Claude Code']),
       input: async (prompt, defaultValue) =>
         prompt.toLowerCase().includes('output') ? symlinkPath : defaultValue,
     })).rejects.toThrow(`Symbolic links are not allowed for skill output file: ${symlinkPath}`);
+  });
+
+  it('should require explicit confirmation when local composition overrides global definition', async () => {
+    const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-workspace-'));
+    const homeDir = mkdtempSync(join(tmpdir(), 'facet-home-'));
+    tempDirs.push(workspaceDir, homeDir);
+    createFacetedFixture(homeDir);
+
+    const localFacetedRoot = join(workspaceDir, '.faceted');
+    mkdirSync(join(localFacetedRoot, 'facets', 'persona'), { recursive: true });
+    mkdirSync(join(localFacetedRoot, 'compositions'), { recursive: true });
+    writeFileSync(join(localFacetedRoot, 'facets', 'persona', 'local-coder.md'), 'local', 'utf-8');
+    writeFileSync(
+      join(localFacetedRoot, 'compositions', 'coding.yaml'),
+      ['name: coding', 'persona: local-coder', 'policies:', '  - coding', 'knowledge:', '  - architecture'].join('\n'),
+      'utf-8',
+    );
+
+    const { runFacetCli } = await loadCliModule();
+    await expect(runFacetCli(['install', 'skill'], {
+      cwd: workspaceDir,
+      homeDir,
+      select: createSelectStub(['coding (local)', 'Codex']),
+      input: async (_prompt, defaultValue) => defaultValue,
+    })).rejects.toThrow('Install was cancelled for local composition: coding');
   });
 
   it('should reject unsupported commands without skill subcommand', async () => {

--- a/src/__tests__/module-boundary.test.ts
+++ b/src/__tests__/module-boundary.test.ts
@@ -13,4 +13,15 @@ describe('module boundary', () => {
     expect('loadComposeDefinition' in resolveModule).toBe(false);
     expect(typeof composeDefinitionModule.loadComposeDefinition).toBe('function');
   });
+
+  it('should not export unused install helpers', async () => {
+    const flowModulePath = pathToFileURL(resolve('src/cli/install-skill/flow.ts')).href;
+    const modesModulePath = pathToFileURL(resolve('src/cli/install-skill/modes.ts')).href;
+    const flowModule = await import(flowModulePath);
+    const modesModule = await import(modesModulePath);
+
+    expect('ensureTemplateDirectory' in flowModule).toBe(false);
+    expect('ensureDirectoryExists' in flowModule).toBe(false);
+    expect('runTemplateApplyInstall' in modesModule).toBe(false);
+  });
 });

--- a/src/__tests__/skill-renderer-regression.test.ts
+++ b/src/__tests__/skill-renderer-regression.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { resolveDefinitionSections } from '../cli/skill-renderer.js';
+
+describe('skill renderer regression', () => {
+  it('should fail when facet roots are not provided', () => {
+    expect(() =>
+      resolveDefinitionSections({
+        definition: {
+          name: 'coding',
+          persona: 'coder',
+        },
+        definitionDir: '/tmp',
+        facetsRoots: [],
+      }),
+    ).toThrow('Facet roots are required');
+  });
+});

--- a/src/cli/compose-context.ts
+++ b/src/cli/compose-context.ts
@@ -112,9 +112,9 @@ function detectGitRelatedFiles(cwd: string): string[] {
 
   const collected = new Set<string>();
   const commands: string[][] = [
-    ['diff', '--name-only', '--diff-filter=ACMR'],
-    ['diff', '--name-only', '--cached', '--diff-filter=ACMR'],
-    ['ls-files', '--others', '--exclude-standard'],
+    ['diff', '--name-only', '--diff-filter=ACMR', '--', '.'],
+    ['diff', '--name-only', '--cached', '--diff-filter=ACMR', '--', '.'],
+    ['ls-files', '--others', '--exclude-standard', '--', '.'],
   ];
 
   for (const args of commands) {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,8 +1,12 @@
 import { existsSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
+import { resolve } from 'node:path';
 import { compose } from '../compose.js';
-import { readFacetedConfig } from '../config/index.js';
-import { initializeFacetedHome, listPullSampleTargetPaths, pullSampleFacets } from '../init/index.js';
+import {
+  initializeGlobalFaceted,
+  initializeLocalFaceted,
+  listPullSampleTargetPaths,
+  pullSampleFacets,
+} from '../init/index.js';
 import { formatCombinedOutput, resolveOutputDirectory, writeComposeOutput } from '../output/index.js';
 import { resolveComposeContext } from './compose-context.js';
 import { buildFacetSet, ensureSafeDefinitionName } from './skill-renderer.js';
@@ -17,7 +21,8 @@ const USAGE = [
   'Usage: facet <command>',
   '',
   'Commands:',
-  '  init                 Initialize local faceted home',
+  '  init                 Initialize local faceted home (.faceted under cwd)',
+  '  init global          Initialize global faceted home (~/.faceted) and pull sample facets',
   '  pull-sample          Pull sample coding facets from TAKT on GitHub',
   '  compose              Compose facets into a prompt file',
   '  install skill        Install a skill from a composition',
@@ -37,7 +42,7 @@ function ensureSkillSubcommand(command: string, subcommand: string | undefined):
 }
 
 async function runComposeCommand(options: FacetCliOptions): Promise<FacetCliResult> {
-  const { facetsRoot, compositionsDir } = getSkillPaths(options.homeDir);
+  const { facetsRoots, facetedRoots } = getSkillPaths(options.cwd, options.homeDir);
   const composeContext = resolveComposeContext(options.cwd);
   const definition = {
     name: composeContext.name,
@@ -47,11 +52,14 @@ async function runComposeCommand(options: FacetCliOptions): Promise<FacetCliResu
     instruction: composeContext.relatedInstruction,
     order: ['policies', 'knowledge', 'instruction'] as const,
   };
-  const definitionDir = dirname(compositionsDir);
+  const definitionDir = facetedRoots[0];
+  if (!definitionDir) {
+    throw new Error('Faceted root is required');
+  }
 
   const facetSet = buildFacetSet({
     definitionDir,
-    facetsRoot,
+    facetsRoots,
     definition,
   });
 
@@ -134,11 +142,23 @@ export async function runFacetCli(
   const subcommand = args[1];
 
   if (command === 'init') {
-    await initializeFacetedHome({ homeDir: options.homeDir });
-    return {
-      kind: 'text',
-      text: `Initialized: ${resolve(options.homeDir, '.faceted')}`,
-    };
+    if (subcommand === undefined) {
+      await initializeLocalFaceted({ cwd: options.cwd });
+      return {
+        kind: 'text',
+        text: `Initialized: ${resolve(options.cwd, '.faceted')}`,
+      };
+    }
+
+    if (subcommand === 'global') {
+      await initializeGlobalFaceted({ homeDir: options.homeDir });
+      return {
+        kind: 'text',
+        text: `Initialized global with sample facets: ${resolve(options.homeDir, '.faceted')}`,
+      };
+    }
+
+    throw new Error(`Unsupported command: ${command} ${subcommand}`);
   }
 
   if (command === 'pull-sample') {
@@ -166,8 +186,6 @@ export async function runFacetCli(
   if (command !== 'compose' && command !== 'install') {
     throw new Error(`Unsupported command: ${command}`);
   }
-
-  await readFacetedConfig(options.homeDir);
 
   if (command === 'compose') {
     return runComposeCommand(options);

--- a/src/cli/install-skill/flow.ts
+++ b/src/cli/install-skill/flow.ts
@@ -6,7 +6,7 @@ import {
   readdirSync,
   rmSync,
 } from 'node:fs';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import {
   ensurePathAncestorsAndRealPathWithinHome,
   ensurePathAncestorsContainNoSymbolicLinks,
@@ -20,19 +20,33 @@ export function shouldOverwrite(answer: string): boolean {
   return normalized === 'y' || normalized === 'yes';
 }
 
-export function ensureTemplateDirectory(facetedRoot: string, templateName: string): string {
-  const templatesRoot = join(facetedRoot, 'templates');
-  const templatePath = ensurePathWithinRoots(
-    join(templatesRoot, templateName),
-    [templatesRoot],
-    `template "${templateName}"`,
-  );
-
-  if (!lstatSync(templatePath).isDirectory()) {
-    throw new Error(`Template path must be a directory: ${templatePath}`);
+export function ensureTemplateDirectoryFromRoots(
+  facetedRoots: readonly string[],
+  templateName: string,
+): string {
+  const templatesRoots = facetedRoots.map(facetedRoot => join(facetedRoot, 'templates'));
+  const primaryTemplatesRoot = templatesRoots[0];
+  if (!primaryTemplatesRoot) {
+    throw new Error('Template roots are required');
   }
 
-  return templatePath;
+  for (const templatesRoot of templatesRoots) {
+    const candidatePath = join(templatesRoot, templateName);
+    if (!existsSync(candidatePath)) {
+      continue;
+    }
+    const templatePath = ensurePathWithinRoots(
+      candidatePath,
+      [templatesRoot],
+      `template "${templateName}"`,
+    );
+    if (!lstatSync(templatePath).isDirectory()) {
+      throw new Error(`Template path must be a directory: ${templatePath}`);
+    }
+    return templatePath;
+  }
+
+  throw new Error(`Template directory does not exist: ${join(primaryTemplatesRoot, templateName)}`);
 }
 
 export function copyDirectoryTree(sourceDir: string, targetDir: string): void {
@@ -78,6 +92,9 @@ export async function ensureRegenerationTargetDir(params: {
   homeDir?: string;
 }): Promise<void> {
   const { targetDir, options, promptLabel } = params;
+  if (params.homeDir && resolve(targetDir) === resolve(params.homeDir)) {
+    throw new Error(`${promptLabel} must not be home directory: ${resolve(targetDir)}`);
+  }
   ensurePathSafety({
     targetDir,
     promptLabel,
@@ -94,10 +111,4 @@ export async function ensureRegenerationTargetDir(params: {
   }
 
   mkdirSync(targetDir, { recursive: true });
-}
-
-export function ensureDirectoryExists(path: string, label: string): void {
-  if (!existsSync(path) || !lstatSync(path).isDirectory()) {
-    throw new Error(`${label} does not exist: ${path}`);
-  }
 }

--- a/src/cli/install-skill/modes.ts
+++ b/src/cli/install-skill/modes.ts
@@ -1,6 +1,6 @@
 import { existsSync, lstatSync, readFileSync } from 'node:fs';
-import { dirname, join, resolve } from 'node:path';
-import { ensurePathWithinHome } from '../path-guard.js';
+import { basename, dirname, resolve } from 'node:path';
+import { ensurePathWithinHome, isWithinRoot } from '../path-guard.js';
 import { hasYamlFrontmatter, renderSkillDocument, renderSkillFrontmatter } from '../skill-renderer.js';
 import { writeSkillFile } from '../skill-file-ops.js';
 import type { FacetCliOptions, FacetCliResult } from '../types.js';
@@ -8,15 +8,13 @@ import {
   applyFacetTokensToPath,
   buildInlineFacetTokenValues,
   copyFacetFiles,
-  parseScanDepth,
 } from './facets.js';
 import {
   copyDirectoryTree,
   defaultOutputPath,
-  ensureDirectoryExists,
   ensureRegenerationTargetDir,
   listInstallTargets,
-  ensureTemplateDirectory,
+  ensureTemplateDirectoryFromRoots,
   resolveInstallTarget,
 } from './flow.js';
 import type { SkillSections } from './facets.js';
@@ -42,63 +40,11 @@ function ensureTemplateBackedSkillFrontmatter(params: {
   writeSkillFile(params.outputPath, contentWithFrontmatter, params.homeDir);
 }
 
-export async function runTemplateApplyInstall(params: {
-  options: FacetCliOptions;
-  safeSkillName: string;
-  sections: SkillSections;
-  templateDir: string;
-  definitionDir: string;
-  facetsRoot: string;
-}): Promise<FacetCliResult> {
-  const requestedDir = await params.options.input('Output directory', params.options.cwd);
-  const targetDir = resolve(requestedDir);
-  ensureDirectoryExists(targetDir, 'Output directory');
-
-  const scanDepth = parseScanDepth(await params.options.input('Scan depth', '1'));
-  const payload = composePromptPayload({
-    definition: params.sections.definition,
-    definitionDir: params.definitionDir,
-    facetsRoot: params.facetsRoot,
-    composeOptions: { contextMaxChars: 8000 },
-  });
-
-  copyDirectoryTree(params.templateDir, targetDir);
-
-  const facetsDir = join(targetDir, 'facets');
-  await ensureRegenerationTargetDir({
-    targetDir: facetsDir,
-    options: params.options,
-    promptLabel: 'Facets directory',
-  });
-
-  copyFacetFiles({
-    targetDir,
-    safeSkillName: params.safeSkillName,
-    copyFiles: payload.copyFiles,
-    literalInstructionBody:
-      params.sections.instruction && !('path' in params.sections.instruction)
-        ? params.sections.instruction.body
-        : undefined,
-  });
-
-  applyFacetTokensToPath({
-    rootDir: targetDir,
-    maxDepth: scanDepth,
-    tokenValues: buildInlineFacetTokenValues(params.sections),
-    excludeDirs: ['facets'],
-  });
-
-  return {
-    kind: 'path',
-    path: targetDir,
-  };
-}
-
 export async function runSkillDeployInstall(params: {
   options: FacetCliOptions;
-  facetedRoot: string;
+  facetedRoots: readonly string[];
   definitionDir: string;
-  facetsRoot: string;
+  facetsRoots: readonly string[];
   safeSkillName: string;
   definition: ComposeDefinition;
   sections: SkillSections;
@@ -116,21 +62,31 @@ export async function runSkillDeployInstall(params: {
     params.options.homeDir,
     'Skill output path',
   );
+  const targetRootDir = resolve(params.options.homeDir, ...target.relativeOutputPath);
+  if (!isWithinRoot(boundedOutputPath, targetRootDir)) {
+    throw new Error(`Skill output path must be inside target directory: ${targetRootDir}`);
+  }
+  if (basename(boundedOutputPath) !== 'SKILL.md') {
+    throw new Error(`Skill output path must point to SKILL.md: ${boundedOutputPath}`);
+  }
 
   if (existsSync(boundedOutputPath) && lstatSync(boundedOutputPath).isSymbolicLink()) {
     throw new Error(`Symbolic links are not allowed for skill output file: ${boundedOutputPath}`);
   }
 
   const templateDir = params.definition.template
-    ? ensureTemplateDirectory(params.facetedRoot, params.definition.template)
+    ? ensureTemplateDirectoryFromRoots(params.facetedRoots, params.definition.template)
     : undefined;
   const payload = composePromptPayload({
     definition: params.definition,
     definitionDir: params.definitionDir,
-    facetsRoot: params.facetsRoot,
+    facetsRoots: params.facetsRoots,
     composeOptions: { contextMaxChars: 8000 },
   });
   const targetDir = dirname(boundedOutputPath);
+  if (resolve(targetDir) === targetRootDir) {
+    throw new Error(`Skill output path must include a skill directory under target directory: ${targetRootDir}`);
+  }
 
   await ensureRegenerationTargetDir({
     targetDir,

--- a/src/cli/skill-commands.ts
+++ b/src/cli/skill-commands.ts
@@ -1,4 +1,5 @@
-import { dirname, join } from 'node:path';
+import { existsSync } from 'node:fs';
+import { dirname, join, resolve, sep } from 'node:path';
 import { loadComposeDefinition } from '../compose-definition.js';
 import { getFacetedRoot } from '../config/index.js';
 import {
@@ -9,35 +10,95 @@ import {
 import type { FacetCliOptions, FacetCliResult } from './types.js';
 import { runSkillDeployInstall } from './install-skill/modes.js';
 
-export function getSkillPaths(homeDir: string): {
-  readonly facetedRoot: string;
-  readonly facetsRoot: string;
-  readonly compositionsDir: string;
+export function getSkillPaths(cwd: string, homeDir: string): {
+  readonly facetedRoots: readonly string[];
+  readonly facetsRoots: readonly string[];
+  readonly compositionsDirs: readonly string[];
 } {
-  const facetedRoot = getFacetedRoot(homeDir);
+  const globalFacetedRoot = getFacetedRoot(homeDir);
+  const localFacetedRoot = getFacetedRoot(cwd);
+  const facetedRoots = existsSync(localFacetedRoot)
+    ? Array.from(new Set([localFacetedRoot, globalFacetedRoot]))
+    : [globalFacetedRoot];
+
   return {
-    facetedRoot,
-    facetsRoot: join(facetedRoot, 'facets'),
-    compositionsDir: join(facetedRoot, 'compositions'),
+    facetedRoots,
+    facetsRoots: facetedRoots.map(facetedRoot => join(facetedRoot, 'facets')),
+    compositionsDirs: facetedRoots.map(facetedRoot => join(facetedRoot, 'compositions')),
   };
 }
 
-export async function runInstallSkillCommand(options: FacetCliOptions): Promise<FacetCliResult> {
-  const { facetedRoot, facetsRoot, compositionsDir } = getSkillPaths(options.homeDir);
-
-  const definitionMap = listCompositionDefinitions(compositionsDir);
-  const compositionCandidates = Object.keys(definitionMap).sort();
-  if (compositionCandidates.length === 0) {
-    throw new Error(`No compose definitions found in ${compositionsDir}`);
+function resolveCompositionSource(
+  definitionPath: string,
+  localCompositionsDir: string | undefined,
+): 'local' | 'global' {
+  if (
+    localCompositionsDir &&
+    resolve(definitionPath).startsWith(`${resolve(localCompositionsDir)}${sep}`)
+  ) {
+    return 'local';
   }
 
-  const selectedComposition = await options.select(
+  return 'global';
+}
+
+function hasGlobalCompositionShadow(
+  compositionName: string,
+  globalCompositionsDir: string,
+): boolean {
+  if (
+    existsSync(join(globalCompositionsDir, `${compositionName}.yaml`)) ||
+    existsSync(join(globalCompositionsDir, `${compositionName}.yml`))
+  ) {
+    return true;
+  }
+  return false;
+}
+
+export async function runInstallSkillCommand(options: FacetCliOptions): Promise<FacetCliResult> {
+  const { facetedRoots, facetsRoots, compositionsDirs } = getSkillPaths(options.cwd, options.homeDir);
+  const localFacetedRoot = getFacetedRoot(options.cwd);
+  const globalFacetedRoot = getFacetedRoot(options.homeDir);
+  const localCompositionsDir = existsSync(localFacetedRoot) ? join(localFacetedRoot, 'compositions') : undefined;
+  const globalCompositionsDir = join(globalFacetedRoot, 'compositions');
+
+  const definitionMap = listCompositionDefinitions(compositionsDirs);
+  const compositionCandidates = Object.keys(definitionMap)
+    .sort()
+    .map(name => {
+      const definitionPath = definitionMap[name];
+      if (!definitionPath) {
+        throw new Error(`Unknown compose definition: ${name}`);
+      }
+      const source = resolveCompositionSource(definitionPath, localCompositionsDir);
+      return source === 'local' ? `${name} (local)` : `${name} (global)`;
+    });
+  if (compositionCandidates.length === 0) {
+    throw new Error(`No compose definitions found in ${compositionsDirs.join(', ')}`);
+  }
+
+  const selectedLabel = await options.select(
     compositionCandidates,
     'Choose composition with Up/Down and Enter:',
   );
+  const selectedComposition = selectedLabel.replace(/ \((local|global)\)$/u, '');
   const definitionPath = definitionMap[selectedComposition];
   if (!definitionPath) {
     throw new Error(`Unknown compose definition selected: ${selectedComposition}`);
+  }
+
+  if (
+    resolveCompositionSource(definitionPath, localCompositionsDir) === 'local' &&
+    hasGlobalCompositionShadow(selectedComposition, globalCompositionsDir)
+  ) {
+    const approved = await options.input(
+      `Local composition "${selectedComposition}" overrides global definition. Continue? [y/N]`,
+      'n',
+    );
+    const normalized = approved.trim().toLowerCase();
+    if (normalized !== 'y' && normalized !== 'yes') {
+      throw new Error(`Install was cancelled for local composition: ${selectedComposition}`);
+    }
   }
 
   const definition = await loadComposeDefinition(definitionPath);
@@ -46,14 +107,14 @@ export async function runInstallSkillCommand(options: FacetCliOptions): Promise<
   const sections = buildSkillSections({
     definition,
     definitionDir,
-    facetsRoot,
+    facetsRoots,
   });
 
   return (await runSkillDeployInstall({
     options,
-    facetedRoot,
+    facetedRoots,
     definitionDir,
-    facetsRoot,
+    facetsRoots,
     safeSkillName,
     definition,
     sections,

--- a/src/cli/skill-renderer.ts
+++ b/src/cli/skill-renderer.ts
@@ -28,34 +28,60 @@ function resolveFacetRefContent(options: {
   ref: string;
   label: string;
   baseDir: string;
-  facetDir: string;
+  facetDirs: readonly string[];
   allowedRoots: readonly string[];
 }): { body: string; path: string } {
-  const { ref, label, baseDir, facetDir, allowedRoots } = options;
+  const { ref, label, baseDir, facetDirs, allowedRoots } = options;
+  const primaryFacetDir = facetDirs[0];
+  if (!primaryFacetDir) {
+    throw new Error(`Missing ${label}: facet directory is required`);
+  }
   if (isResourcePath(ref)) {
     const resourcePath = resolveResourcePath(ref, baseDir);
     const boundedPath = ensurePathWithinRoots(resourcePath, allowedRoots, label);
     return { path: boundedPath, body: requireFile(boundedPath, label) };
   }
 
-  const facetPath = join(facetDir, `${ref}.md`);
-  const boundedPath = ensurePathWithinRoots(facetPath, allowedRoots, label);
-  return { path: boundedPath, body: requireFile(boundedPath, label) };
+  for (const facetDir of facetDirs) {
+    const facetPath = join(facetDir, `${ref}.md`);
+    if (!existsSync(facetPath)) {
+      continue;
+    }
+    const boundedPath = ensurePathWithinRoots(facetPath, allowedRoots, label);
+    return { path: boundedPath, body: requireFile(boundedPath, label) };
+  }
+
+  throw new Error(`Missing ${label}: ${join(primaryFacetDir, `${ref}.md`)}`);
+}
+
+function resolveFacetsRoots(params: {
+  facetsRoot?: string;
+  facetsRoots?: readonly string[];
+}): readonly string[] {
+  if (params.facetsRoots && params.facetsRoots.length > 0) {
+    return params.facetsRoots;
+  }
+  if (params.facetsRoot) {
+    return [params.facetsRoot];
+  }
+  throw new Error('Facet roots are required');
 }
 
 export function resolveDefinitionSections(params: {
   definition: ComposeDefinition;
   definitionDir: string;
-  facetsRoot: string;
+  facetsRoot?: string;
+  facetsRoots?: readonly string[];
 }): ResolvedDefinitionSections {
-  const { definition, definitionDir, facetsRoot } = params;
-  const allowedRoots = [facetsRoot];
+  const { definition, definitionDir } = params;
+  const facetsRoots = resolveFacetsRoots(params);
+  const allowedRoots = facetsRoots;
 
   const personaContent = resolveFacetRefContent({
     ref: definition.persona,
     label: `persona facet "${definition.persona}"`,
     baseDir: definitionDir,
-    facetDir: join(facetsRoot, 'persona'),
+    facetDirs: facetsRoots.map(facetsRoot => join(facetsRoot, 'persona')),
     allowedRoots,
   });
 
@@ -65,7 +91,7 @@ export function resolveDefinitionSections(params: {
         ref,
         label: `policy facet "${ref}"`,
         baseDir: definitionDir,
-        facetDir: join(facetsRoot, 'policies'),
+        facetDirs: facetsRoots.map(facetsRoot => join(facetsRoot, 'policies')),
         allowedRoots,
       });
       return { ref, body: resolved.body, path: resolved.path };
@@ -77,7 +103,7 @@ export function resolveDefinitionSections(params: {
         ref,
         label: `knowledge facet "${ref}"`,
         baseDir: definitionDir,
-        facetDir: join(facetsRoot, 'knowledge'),
+        facetDirs: facetsRoots.map(facetsRoot => join(facetsRoot, 'knowledge')),
         allowedRoots,
       });
       return { ref, body: resolved.body, path: resolved.path };
@@ -90,7 +116,7 @@ export function resolveDefinitionSections(params: {
         ref: definition.instruction,
         label: 'instruction file',
         baseDir: definitionDir,
-        facetDir: facetsRoot,
+        facetDirs: facetsRoots,
         allowedRoots,
       });
       instruction = {
@@ -118,24 +144,32 @@ export function resolveDefinitionSections(params: {
   };
 }
 
-export function listCompositionDefinitions(compositionsDir: string): Record<string, string> {
-  if (!existsSync(compositionsDir)) {
-    throw new Error(`Compose definition directory does not exist: ${compositionsDir}`);
-  }
-
-  const entries = readdirSync(compositionsDir, { withFileTypes: true })
-    .filter(entry => !entry.isDirectory() && (entry.name.endsWith('.yaml') || entry.name.endsWith('.yml')))
-    .map(entry => entry.name);
-
+export function listCompositionDefinitions(compositionsDirs: string | readonly string[]): Record<string, string> {
+  const dirs = Array.isArray(compositionsDirs) ? compositionsDirs : [compositionsDirs];
   const definitions: Record<string, string> = {};
-  for (const entry of entries) {
-    const name = entry.replace(/\.(yaml|yml)$/u, '');
-    const definitionPath = join(compositionsDir, entry);
-    definitions[name] = ensurePathWithinRoots(
-      definitionPath,
-      [compositionsDir],
-      `compose definition "${entry}"`,
-    );
+
+  for (const compositionsDir of dirs) {
+    if (!existsSync(compositionsDir)) {
+      continue;
+    }
+
+    const entries = readdirSync(compositionsDir, { withFileTypes: true })
+      .filter(entry => !entry.isDirectory() && (entry.name.endsWith('.yaml') || entry.name.endsWith('.yml')))
+      .map(entry => entry.name)
+      .sort();
+
+    for (const entry of entries) {
+      const name = entry.replace(/\.(yaml|yml)$/u, '');
+      if (name in definitions) {
+        continue;
+      }
+      const definitionPath = join(compositionsDir, entry);
+      definitions[name] = ensurePathWithinRoots(
+        definitionPath,
+        [compositionsDir],
+        `compose definition "${entry}"`,
+      );
+    }
   }
 
   return definitions;
@@ -143,7 +177,8 @@ export function listCompositionDefinitions(compositionsDir: string): Record<stri
 
 export function buildFacetSet(params: {
   definitionDir: string;
-  facetsRoot: string;
+  facetsRoot?: string;
+  facetsRoots?: readonly string[];
   definition: ComposeDefinition;
 }): FacetSet {
   const resolved = resolveDefinitionSections(params);
@@ -163,7 +198,8 @@ export function buildFacetSet(params: {
 export function buildSkillSections(params: {
   definition: ComposeDefinition;
   definitionDir: string;
-  facetsRoot: string;
+  facetsRoot?: string;
+  facetsRoots?: readonly string[];
 }): Omit<SkillDocumentInput, 'mode'> {
   const { definition } = params;
   const resolved = resolveDefinitionSections(params);

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -184,6 +184,24 @@ export function listPullSampleTargetPaths(homeDir: string): string[] {
   ];
 }
 
+function initializeFacetedDir(baseDir: string): string {
+  const facetedRoot = getFacetedRoot(baseDir);
+  ensureConfigFile(baseDir);
+
+  const facetsRoot = join(facetedRoot, 'facets');
+  const compositionsRoot = join(facetedRoot, 'compositions');
+  const templatesRoot = join(facetedRoot, 'templates');
+  mkdirSync(facetsRoot, { recursive: true });
+  mkdirSync(compositionsRoot, { recursive: true });
+  mkdirSync(templatesRoot, { recursive: true });
+
+  for (const dirName of REQUIRED_FACET_DIRS) {
+    mkdirSync(join(facetsRoot, dirName), { recursive: true });
+  }
+
+  return facetedRoot;
+}
+
 async function bootstrapDefaultFacets(facetedRoot: string, fetchImpl: FetchLike, overwrite: boolean): Promise<void> {
   for (const target of BOOTSTRAP_TARGETS) {
     const targetPath = join(facetedRoot, target.localRelativePath);
@@ -208,25 +226,19 @@ function writeDefaultSampleFiles(facetedRoot: string, overwrite: boolean): void 
   }
 }
 
-export async function initializeFacetedHome(options: { homeDir: string }): Promise<void> {
-  const facetedRoot = getFacetedRoot(options.homeDir);
-  ensureConfigFile(options.homeDir);
+export async function initializeLocalFaceted(options: { cwd: string }): Promise<void> {
+  initializeFacetedDir(options.cwd);
+}
 
-  const facetsRoot = join(facetedRoot, 'facets');
-  const compositionsRoot = join(facetedRoot, 'compositions');
-  const templatesRoot = join(facetedRoot, 'templates');
-  mkdirSync(facetsRoot, { recursive: true });
-  mkdirSync(compositionsRoot, { recursive: true });
-  mkdirSync(templatesRoot, { recursive: true });
-
-  for (const dirName of REQUIRED_FACET_DIRS) {
-    mkdirSync(join(facetsRoot, dirName), { recursive: true });
-  }
+export async function initializeGlobalFaceted(options: { homeDir: string; fetchImpl?: FetchLike }): Promise<void> {
+  await pullSampleFacets({
+    homeDir: options.homeDir,
+    fetchImpl: options.fetchImpl,
+  });
 }
 
 export async function pullSampleFacets(options: { homeDir: string; fetchImpl?: FetchLike; overwrite?: boolean }): Promise<void> {
-  await initializeFacetedHome({ homeDir: options.homeDir });
-  const facetedRoot = getFacetedRoot(options.homeDir);
+  const facetedRoot = initializeFacetedDir(options.homeDir);
   const overwrite = options.overwrite ?? false;
   writeDefaultSampleFiles(facetedRoot, overwrite);
   await bootstrapDefaultFacets(facetedRoot, resolveFetchImpl(options.fetchImpl), overwrite);

--- a/src/prompt-payload.ts
+++ b/src/prompt-payload.ts
@@ -5,7 +5,8 @@ import { buildFacetSet, resolveDefinitionSections } from './cli/skill-renderer.j
 function buildCopyFiles(params: {
   definition: ComposeDefinition;
   definitionDir: string;
-  facetsRoot: string;
+  facetsRoot?: string;
+  facetsRoots?: readonly string[];
 }): CopyFiles {
   const resolved = resolveDefinitionSections(params);
 
@@ -21,7 +22,8 @@ function buildCopyFiles(params: {
 export function composePromptPayload(params: {
   definition: ComposeDefinition;
   definitionDir: string;
-  facetsRoot: string;
+  facetsRoot?: string;
+  facetsRoots?: readonly string[];
   composeOptions: ComposeOptions;
 }): ComposedPromptPayload {
   const facetSet = buildFacetSet(params);


### PR DESCRIPTION
## Summary

## 概要

`facet init` のデフォルト動作を変更し、プロジェクトローカルの `./.faceted` を作成するようにする。グローバル (`~/.faceted`) は `facet init global` で別途作成する。

## 背景

プロジェクトごとにファセットをローカル管理したい。グローバルとローカルを `CompositeDataEngine` でマージし、ローカル優先・グローバルフォールバックで解決する。

## 変更内容

### `facet init`（ローカル）
- `./.faceted` にディレクトリ構造と `config.yaml` を作成
- サンプルファセットは含めない（グローバルにある前提）

### `facet init global`
- `~/.faceted` を作成（現行の `facet init` 相当）
- `pull-sample` 相当のサンプルファセット取得も実施

### DataEngine のマージ
- CLI 実行時に CWD の `./.faceted` を検出
- 存在すれば `CompositeDataEngine([local, global])` でローカル優先チェイン
- compositions / templates も同様にローカル優先探索

## 参考
- `CompositeDataEngine` が first-match-wins で既にこのユースケースに対応済み
- `config.yaml` のマージ戦略（`skillPaths` の結合など）も検討が必要

## Execution Report

Piece `takt-default` completed successfully.

Closes #15