### PR TITLE
[#19] extend-compose-compositions

### DIFF
--- a/src/__tests__/it-cli-compose-flow.test.ts
+++ b/src/__tests__/it-cli-compose-flow.test.ts
@@ -1,4 +1,3 @@
-import { execFileSync } from 'node:child_process';
 import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
@@ -32,10 +31,42 @@ async function runInit(runFacetCli: CliModule['runFacetCli'], workspaceDir: stri
   });
 }
 
+function createSelectStub(expectedSelections: readonly string[]) {
+  const queue = [...expectedSelections];
+  return async (candidates: string[]): Promise<string> => {
+    const next = queue.shift();
+    if (!next) {
+      throw new Error(`Unexpected select call: ${candidates.join(', ')}`);
+    }
+    expect(candidates).toContain(next);
+    return next;
+  };
+}
+
+function writeCodingComposition(compositionsRoot: string): void {
+  mkdirSync(compositionsRoot, { recursive: true });
+  writeFileSync(
+    join(compositionsRoot, 'coding.yaml'),
+    [
+      'name: coding',
+      'description: Coding workflow',
+      'persona: coder',
+      'policies:',
+      '  - coding',
+      '  - ai-antipattern',
+      'knowledge:',
+      '  - architecture',
+      'instruction: Keep changes small and explicit.',
+    ].join('\n'),
+    'utf-8',
+  );
+}
+
 function writeDefaultFacetFixture(homeDir: string, persona = 'You are a coding agent.\n'): void {
-  mkdirSync(join(homeDir, '.faceted'), { recursive: true });
-  writeFileSync(join(homeDir, '.faceted', 'config.yaml'), 'version: 1\n', 'utf-8');
-  const facetsRoot = join(homeDir, '.faceted', 'facets');
+  const facetedRoot = join(homeDir, '.faceted');
+  const facetsRoot = join(facetedRoot, 'facets');
+  mkdirSync(facetedRoot, { recursive: true });
+  writeFileSync(join(facetedRoot, 'config.yaml'), 'version: 1\n', 'utf-8');
   mkdirSync(join(facetsRoot, 'persona'), { recursive: true });
   mkdirSync(join(facetsRoot, 'knowledge'), { recursive: true });
   mkdirSync(join(facetsRoot, 'policies'), { recursive: true });
@@ -45,6 +76,7 @@ function writeDefaultFacetFixture(homeDir: string, persona = 'You are a coding a
   writeFileSync(join(facetsRoot, 'knowledge', 'backend.md'), 'Backend reference.\n', 'utf-8');
   writeFileSync(join(facetsRoot, 'policies', 'coding.md'), 'Never hide errors.\n', 'utf-8');
   writeFileSync(join(facetsRoot, 'policies', 'ai-antipattern.md'), 'Do not add dead code.\n', 'utf-8');
+  writeCodingComposition(join(facetedRoot, 'compositions'));
 }
 
 function writeFacetFilesUnderFacetedRoot(
@@ -69,6 +101,56 @@ function writeFacetFilesUnderFacetedRoot(
   writeFileSync(join(facetsRoot, 'knowledge', 'backend.md'), contents.backend, 'utf-8');
   writeFileSync(join(facetsRoot, 'policies', 'coding.md'), contents.codingPolicy, 'utf-8');
   writeFileSync(join(facetsRoot, 'policies', 'ai-antipattern.md'), contents.aiAntipatternPolicy, 'utf-8');
+  writeCodingComposition(join(facetedRoot, 'compositions'));
+}
+
+function writeTemplateCompositionFixture(homeDir: string): void {
+  const facetedRoot = join(homeDir, '.faceted');
+  const facetsRoot = join(facetedRoot, 'facets');
+  const compositionsRoot = join(facetedRoot, 'compositions');
+  const templateRoot = join(facetedRoot, 'templates', 'starter-kit');
+
+  mkdirSync(join(facetsRoot, 'persona'), { recursive: true });
+  mkdirSync(join(facetsRoot, 'knowledge'), { recursive: true });
+  mkdirSync(join(facetsRoot, 'policies'), { recursive: true });
+  mkdirSync(compositionsRoot, { recursive: true });
+  mkdirSync(templateRoot, { recursive: true });
+
+  writeFileSync(join(facetedRoot, 'config.yaml'), 'version: 1\n', 'utf-8');
+  writeFileSync(join(facetsRoot, 'persona', 'coder.md'), 'You are a template coding agent.', 'utf-8');
+  writeFileSync(join(facetsRoot, 'knowledge', 'architecture.md'), 'Template architecture knowledge.', 'utf-8');
+  writeFileSync(join(facetsRoot, 'policies', 'coding.md'), 'Template coding policy.', 'utf-8');
+
+  writeFileSync(
+    join(compositionsRoot, 'templated.yaml'),
+    [
+      'name: templated',
+      'persona: coder',
+      'knowledge:',
+      '  - architecture',
+      'policies:',
+      '  - coding',
+      'instruction: Keep template output deterministic.',
+      'template: starter-kit',
+    ].join('\n'),
+    'utf-8',
+  );
+
+  writeFileSync(
+    join(templateRoot, 'prompt.yaml'),
+    [
+      'persona: |',
+      '  {{facet:persona}}',
+      'knowledge: |',
+      '  {{facet:knowledges}}',
+      'policies: |',
+      '  {{facet:policies}}',
+      'instruction: |',
+      '  {{facet:instructions}}',
+    ].join('\n'),
+    'utf-8',
+  );
+  writeFileSync(join(templateRoot, 'README.md'), 'template file', 'utf-8');
 }
 
 describe('facet compose integration flow', () => {
@@ -80,32 +162,12 @@ describe('facet compose integration flow', () => {
     }
   });
 
-  it('should auto-select frontend knowledge and include related files in the composed prompt', async () => {
+  it('should compose selected global composition in combined mode', async () => {
     const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-workspace-'));
     const homeDir = mkdtempSync(join(tmpdir(), 'facet-home-'));
     tempDirs.push(workspaceDir, homeDir);
 
-    const facetedRoot = join(homeDir, '.faceted');
-    const facetsRoot = join(facetedRoot, 'facets');
-
-    mkdirSync(join(facetsRoot, 'persona'), { recursive: true });
-    mkdirSync(join(facetsRoot, 'knowledge'), { recursive: true });
-    mkdirSync(join(facetsRoot, 'policies'), { recursive: true });
-
-    writeFileSync(join(facetedRoot, 'config.yaml'), 'version: 1\n', 'utf-8');
-    writeFileSync(join(facetsRoot, 'persona', 'coder.md'), 'You are a release engineer.', 'utf-8');
-    writeFileSync(join(facetsRoot, 'knowledge', 'architecture.md'), 'System architecture notes.', 'utf-8');
-    writeFileSync(join(facetsRoot, 'knowledge', 'frontend.md'), 'Frontend implementation notes.', 'utf-8');
-    writeFileSync(join(facetsRoot, 'knowledge', 'backend.md'), 'Backend implementation notes.', 'utf-8');
-    writeFileSync(join(facetsRoot, 'policies', 'coding.md'), 'Never hide errors.', 'utf-8');
-    writeFileSync(join(facetsRoot, 'policies', 'ai-antipattern.md'), 'Do not add dead code.', 'utf-8');
-
-    mkdirSync(join(workspaceDir, 'src'), { recursive: true });
-    writeFileSync(
-      join(workspaceDir, 'src', 'App.tsx'),
-      'export function App() { return <main>Hello</main>; }\n',
-      'utf-8',
-    );
+    writeDefaultFacetFixture(homeDir, 'You are a release engineer.\n');
 
     const outputDir = join(workspaceDir, 'out');
     mkdirSync(outputDir, { recursive: true });
@@ -114,7 +176,7 @@ describe('facet compose integration flow', () => {
     const result = await runFacetCli(['compose'], {
       cwd: workspaceDir,
       homeDir,
-      select: async () => 'Combined (single file)',
+      select: createSelectStub(['coding (global)', 'Combined (single file)']),
       input: async (_prompt, defaultValue) => {
         expect(defaultValue).toBe(workspaceDir);
         return outputDir;
@@ -125,25 +187,22 @@ describe('facet compose integration flow', () => {
     if (result.kind !== 'path') {
       throw new Error('Expected path result for compose command');
     }
-    expect(result.path).toBe(join(outputDir, 'frontend.md'));
+    expect(result.path).toBe(join(outputDir, 'coding.md'));
     expect(existsSync(result.path)).toBe(true);
 
     const generated = readFileSync(result.path, 'utf-8');
     expect(generated).toContain('You are a release engineer.');
-    expect(generated).toContain('System architecture notes.');
-    expect(generated).toContain('Frontend implementation notes.');
+    expect(generated).toContain('Architecture reference.');
     expect(generated).toContain('Never hide errors.');
-    expect(generated).toContain('# Related Files');
-    expect(generated).toContain('src/App.tsx');
-    expect(generated).toContain('Source: src/App.tsx');
+    expect(generated).toContain('Do not add dead code.');
+    expect(generated).toContain('Keep changes small and explicit.');
   });
 
-  it('should prefer local facets and fallback to global facets when local facets are missing', async () => {
+  it('should prefer local composition and local facets while falling back to global facets', async () => {
     const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-workspace-'));
     const homeDir = mkdtempSync(join(tmpdir(), 'facet-home-'));
     tempDirs.push(workspaceDir, homeDir);
 
-    writeFileSync(join(workspaceDir, 'server.ts'), 'export const server = true;\n', 'utf-8');
     writeFacetFilesUnderFacetedRoot(join(homeDir, '.faceted'), {
       persona: 'You are a global coder persona.\n',
       codingPolicy: 'Global coding policy.\n',
@@ -156,15 +215,18 @@ describe('facet compose integration flow', () => {
     const localFacetedRoot = join(workspaceDir, '.faceted');
     mkdirSync(join(localFacetedRoot, 'facets', 'persona'), { recursive: true });
     mkdirSync(join(localFacetedRoot, 'facets', 'policies'), { recursive: true });
+    mkdirSync(join(localFacetedRoot, 'compositions'), { recursive: true });
     writeFileSync(join(localFacetedRoot, 'facets', 'persona', 'coder.md'), 'You are a local coder persona.\n', 'utf-8');
     writeFileSync(join(localFacetedRoot, 'facets', 'policies', 'coding.md'), 'Local coding policy.\n', 'utf-8');
+    writeCodingComposition(join(localFacetedRoot, 'compositions'));
 
     const { runFacetCli } = await loadCliModule();
     const result = await runFacetCli(['compose'], {
       cwd: workspaceDir,
       homeDir,
-      select: async () => 'Combined (single file)',
-      input: async (_prompt, defaultValue) => defaultValue,
+      select: createSelectStub(['coding (local)', 'Combined (single file)']),
+      input: async (prompt, defaultValue) =>
+        prompt.includes('overrides global definition') ? 'y' : defaultValue,
     });
 
     expect(result.kind).toBe('path');
@@ -179,12 +241,45 @@ describe('facet compose integration flow', () => {
     expect(generated).toContain('Global architecture knowledge.');
   });
 
+  it('should cancel compose when local composition shadow confirmation is declined', async () => {
+    const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-workspace-'));
+    const homeDir = mkdtempSync(join(tmpdir(), 'facet-home-'));
+    tempDirs.push(workspaceDir, homeDir);
+
+    writeFacetFilesUnderFacetedRoot(join(homeDir, '.faceted'), {
+      persona: 'You are a global coder persona.\n',
+      codingPolicy: 'Global coding policy.\n',
+      aiAntipatternPolicy: 'Global AI antipattern policy.\n',
+      architecture: 'Global architecture knowledge.\n',
+      frontend: 'Global frontend knowledge.\n',
+      backend: 'Global backend knowledge.\n',
+    });
+
+    const localFacetedRoot = join(workspaceDir, '.faceted');
+    mkdirSync(join(localFacetedRoot, 'facets', 'persona'), { recursive: true });
+    mkdirSync(join(localFacetedRoot, 'facets', 'policies'), { recursive: true });
+    mkdirSync(join(localFacetedRoot, 'compositions'), { recursive: true });
+    writeFileSync(join(localFacetedRoot, 'facets', 'persona', 'coder.md'), 'You are a local coder persona.\n', 'utf-8');
+    writeFileSync(join(localFacetedRoot, 'facets', 'policies', 'coding.md'), 'Local coding policy.\n', 'utf-8');
+    writeCodingComposition(join(localFacetedRoot, 'compositions'));
+
+    const { runFacetCli } = await loadCliModule();
+    await expect(runFacetCli(['compose'], {
+      cwd: workspaceDir,
+      homeDir,
+      select: createSelectStub(['coding (local)']),
+      input: async (prompt, defaultValue) =>
+        prompt.includes('overrides global definition') ? 'n' : defaultValue,
+    })).rejects.toThrow('Compose was cancelled for local composition: coding');
+
+    expect(existsSync(join(workspaceDir, 'coding.md'))).toBe(false);
+  });
+
   it('should compose with local facets when global faceted home is not initialized', async () => {
     const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-workspace-'));
     const homeDir = mkdtempSync(join(tmpdir(), 'facet-home-'));
     tempDirs.push(workspaceDir, homeDir);
 
-    writeFileSync(join(workspaceDir, 'api.ts'), 'export const api = true;\n', 'utf-8');
     writeFacetFilesUnderFacetedRoot(join(workspaceDir, '.faceted'), {
       persona: 'You are a local-only coder persona.\n',
       codingPolicy: 'Local-only coding policy.\n',
@@ -198,7 +293,7 @@ describe('facet compose integration flow', () => {
     const result = await runFacetCli(['compose'], {
       cwd: workspaceDir,
       homeDir,
-      select: async () => 'Combined (single file)',
+      select: createSelectStub(['coding (local)', 'Combined (single file)']),
       input: async (_prompt, defaultValue) => defaultValue,
     });
 
@@ -249,7 +344,7 @@ describe('facet compose integration flow', () => {
     const globalFacetedRoot = join(homeDir, '.faceted');
     mkdirSync(globalFacetedRoot, { recursive: true });
     writeFileSync(join(globalFacetedRoot, 'config.yaml'), 'version: [1\n', 'utf-8');
-    writeFileSync(join(workspaceDir, 'service.ts'), 'export const service = true;\n', 'utf-8');
+
     writeFacetFilesUnderFacetedRoot(join(workspaceDir, '.faceted'), {
       persona: 'You are a local malformed-config fallback persona.\n',
       codingPolicy: 'Local malformed-config coding policy.\n',
@@ -263,7 +358,7 @@ describe('facet compose integration flow', () => {
     const result = await runFacetCli(['compose'], {
       cwd: workspaceDir,
       homeDir,
-      select: async () => 'Combined (single file)',
+      select: createSelectStub(['coding (local)', 'Combined (single file)']),
       input: async (_prompt, defaultValue) => defaultValue,
     });
 
@@ -276,7 +371,7 @@ describe('facet compose integration flow', () => {
     expect(generated).toContain('Local malformed-config coding policy.');
   });
 
-  it('should compose after init when required facets are prepared', async () => {
+  it('should compose in split mode after init when definitions are prepared', async () => {
     const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-workspace-'));
     const homeDir = mkdtempSync(join(tmpdir(), 'facet-home-'));
     tempDirs.push(workspaceDir, homeDir);
@@ -295,12 +390,11 @@ describe('facet compose integration flow', () => {
     });
 
     writeDefaultFacetFixture(homeDir, 'You are a prepared coding assistant.\n');
-    writeFileSync(join(workspaceDir, 'server.ts'), 'export const server = true;\n', 'utf-8');
 
     const result = await runFacetCli(['compose'], {
       cwd: workspaceDir,
       homeDir,
-      select: async () => 'Split (system + user)',
+      select: createSelectStub(['coding (global)', 'Split (system + user)']),
       input: async (_prompt, defaultValue) => {
         expect(defaultValue).toBe(workspaceDir);
         return '   ';
@@ -320,39 +414,42 @@ describe('facet compose integration flow', () => {
     const generatedSystem = readFileSync(result.paths[0]!, 'utf-8');
     const generatedUser = readFileSync(result.paths[1]!, 'utf-8');
     expect(generatedSystem).toContain('You are a prepared coding assistant.');
-    expect(generatedUser).toContain('# Related Files');
-    expect(generatedUser).toContain('server.ts');
+    expect(generatedUser).toContain('Never hide errors.');
+    expect(generatedUser).toContain('Keep changes small and explicit.');
   });
 
-  it('should require init before compose', async () => {
+  it('should reject compose when no composition definitions are found', async () => {
     const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-workspace-'));
     const homeDir = mkdtempSync(join(tmpdir(), 'facet-home-'));
     tempDirs.push(workspaceDir, homeDir);
 
     const { runFacetCli } = await loadCliModule();
+    await runInit(runFacetCli, workspaceDir, homeDir);
+
     await expect(runFacetCli(['compose'], {
       cwd: workspaceDir,
       homeDir,
       select: async () => 'unused',
       input: async (_prompt, defaultValue) => defaultValue,
-    })).rejects.toThrow('Missing persona facet "coder"');
+    })).rejects.toThrow('No compose definitions found in');
   });
 
-  it('should truncate related file content and keep source reference', async () => {
+  it('should output template-backed composition files with facet tokens applied', async () => {
     const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-workspace-'));
     const homeDir = mkdtempSync(join(tmpdir(), 'facet-home-'));
     tempDirs.push(workspaceDir, homeDir);
+    writeTemplateCompositionFixture(homeDir);
 
-    writeFileSync(join(workspaceDir, 'long.ts'), `${'x'.repeat(2500)}\n`, 'utf-8');
-
+    const outputDir = join(workspaceDir, 'templated-output');
     const { runFacetCli } = await loadCliModule();
-    await runInit(runFacetCli, workspaceDir, homeDir);
-    writeDefaultFacetFixture(homeDir);
     const result = await runFacetCli(['compose'], {
       cwd: workspaceDir,
       homeDir,
-      select: async () => 'Combined (single file)',
-      input: async (_prompt, defaultValue) => defaultValue,
+      select: createSelectStub(['templated (global)']),
+      input: async (_prompt, defaultValue) => {
+        expect(defaultValue).toBe(workspaceDir);
+        return outputDir;
+      },
     });
 
     expect(result.kind).toBe('path');
@@ -360,52 +457,19 @@ describe('facet compose integration flow', () => {
       throw new Error('Expected path result for compose command');
     }
 
-    const generated = readFileSync(result.path, 'utf-8');
-    expect(generated).toContain('...TRUNCATED...');
-    expect(generated).toContain('Source: long.ts');
-  });
-
-  it('should include only cwd-scoped git files in related files when composing from a subdirectory', async () => {
-    const repositoryDir = mkdtempSync(join(tmpdir(), 'facet-repo-'));
-    const workspaceDir = join(repositoryDir, 'workspace');
-    const homeDir = mkdtempSync(join(tmpdir(), 'facet-home-'));
-    tempDirs.push(repositoryDir, homeDir);
-    mkdirSync(workspaceDir, { recursive: true });
-
-    execFileSync('git', ['init'], { cwd: repositoryDir, stdio: 'pipe' });
-
-    const { runFacetCli } = await loadCliModule();
-    await runInit(runFacetCli, workspaceDir, homeDir);
-    writeDefaultFacetFixture(homeDir);
-    execFileSync('git', ['add', '.'], { cwd: repositoryDir, stdio: 'pipe' });
-
-    mkdirSync(join(workspaceDir, 'src'), { recursive: true });
-    writeFileSync(join(workspaceDir, 'src', 'App.tsx'), 'export const App = () => <div>ok</div>;\n', 'utf-8');
-    writeFileSync(join(repositoryDir, 'outside.ts'), 'export const outside = true;\n', 'utf-8');
-
-    const result = await runFacetCli(['compose'], {
-      cwd: workspaceDir,
-      homeDir,
-      select: async () => 'Combined (single file)',
-      input: async (_prompt, defaultValue) => defaultValue,
-    });
-
-    expect(result.kind).toBe('path');
-    if (result.kind !== 'path') {
-      throw new Error('Expected path result for compose command');
-    }
-
-    const generated = readFileSync(result.path, 'utf-8');
-    expect(generated).toContain('Source: src/App.tsx');
-    expect(generated).not.toContain('outside.ts');
+    const renderedPath = join(outputDir, 'prompt.yaml');
+    expect(existsSync(renderedPath)).toBe(true);
+    expect(readFileSync(renderedPath, 'utf-8')).toContain('You are a template coding agent.');
+    expect(readFileSync(renderedPath, 'utf-8')).toContain('Template architecture knowledge.');
+    expect(readFileSync(renderedPath, 'utf-8')).toContain('Template coding policy.');
+    expect(readFileSync(renderedPath, 'utf-8')).toContain('Keep template output deterministic.');
+    expect(existsSync(join(outputDir, 'README.md'))).toBe(true);
   });
 
   it('should cancel overwrite when output file exists and answer is not y/yes', async () => {
     const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-workspace-'));
     const homeDir = mkdtempSync(join(tmpdir(), 'facet-home-'));
     tempDirs.push(workspaceDir, homeDir);
-
-    writeFileSync(join(workspaceDir, 'server.ts'), 'export const server = true;\n', 'utf-8');
 
     const outputDir = join(workspaceDir, 'out');
     mkdirSync(outputDir, { recursive: true });
@@ -418,7 +482,7 @@ describe('facet compose integration flow', () => {
     await expect(runFacetCli(['compose'], {
       cwd: workspaceDir,
       homeDir,
-      select: async () => 'Combined (single file)',
+      select: createSelectStub(['coding (global)', 'Combined (single file)']),
       input: async (prompt) => {
         if (prompt.startsWith('Output directory')) {
           return outputDir;
@@ -436,8 +500,6 @@ describe('facet compose integration flow', () => {
     const homeDir = mkdtempSync(join(tmpdir(), 'facet-home-'));
     tempDirs.push(workspaceDir, homeDir);
 
-    writeFileSync(join(workspaceDir, 'server.ts'), 'export const server = true;\n', 'utf-8');
-
     const outputDir = join(workspaceDir, 'out');
     mkdirSync(outputDir, { recursive: true });
     const outputPath = join(outputDir, 'coding.md');
@@ -449,7 +511,7 @@ describe('facet compose integration flow', () => {
     const result = await runFacetCli(['compose'], {
       cwd: workspaceDir,
       homeDir,
-      select: async () => 'Combined (single file)',
+      select: createSelectStub(['coding (global)', 'Combined (single file)']),
       input: async (prompt) => {
         if (prompt.startsWith('Output directory')) {
           return outputDir;
@@ -464,15 +526,13 @@ describe('facet compose integration flow', () => {
       throw new Error('Expected path result for compose command');
     }
     expect(result.path).toBe(outputPath);
-    expect(readFileSync(outputPath, 'utf-8')).toContain('server.ts');
+    expect(readFileSync(outputPath, 'utf-8')).toContain('Never hide errors.');
   });
 
   it('should reject writing to a symlinked output file', async () => {
     const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-workspace-'));
     const homeDir = mkdtempSync(join(tmpdir(), 'facet-home-'));
     tempDirs.push(workspaceDir, homeDir);
-
-    writeFileSync(join(workspaceDir, 'server.ts'), 'export const server = true;\n', 'utf-8');
 
     const outputDir = join(workspaceDir, 'out');
     mkdirSync(outputDir, { recursive: true });
@@ -486,7 +546,7 @@ describe('facet compose integration flow', () => {
     await expect(runFacetCli(['compose'], {
       cwd: workspaceDir,
       homeDir,
-      select: async () => 'Combined (single file)',
+      select: createSelectStub(['coding (global)', 'Combined (single file)']),
       input: async (prompt) => {
         if (prompt.startsWith('Output directory')) {
           return outputDir;

--- a/src/__tests__/it-cli-skill-flow.test.ts
+++ b/src/__tests__/it-cli-skill-flow.test.ts
@@ -462,6 +462,36 @@ describe('facet skill integration flow', () => {
     })).rejects.toThrow('Install was cancelled for local composition: coding');
   });
 
+  it('should continue install when local shadow confirmation is yes with extra spaces', async () => {
+    const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-workspace-'));
+    const homeDir = mkdtempSync(join(tmpdir(), 'facet-home-'));
+    tempDirs.push(workspaceDir, homeDir);
+    createFacetedFixture(homeDir);
+
+    const localFacetedRoot = join(workspaceDir, '.faceted');
+    mkdirSync(join(localFacetedRoot, 'facets', 'persona'), { recursive: true });
+    mkdirSync(join(localFacetedRoot, 'compositions'), { recursive: true });
+    writeFileSync(join(localFacetedRoot, 'facets', 'persona', 'local-coder.md'), 'local', 'utf-8');
+    writeFileSync(
+      join(localFacetedRoot, 'compositions', 'coding.yaml'),
+      ['name: coding', 'persona: local-coder', 'policies:', '  - coding', 'knowledge:', '  - architecture'].join('\n'),
+      'utf-8',
+    );
+
+    const outputPath = join(homeDir, '.codex', 'skills', 'coding', 'SKILL.md');
+    const { runFacetCli } = await loadCliModule();
+    const result = await runFacetCli(['install', 'skill'], {
+      cwd: workspaceDir,
+      homeDir,
+      select: createSelectStub(['coding (local)', 'Codex']),
+      input: async (prompt, defaultValue) =>
+        prompt.includes('overrides global definition') ? '  YeS  ' : defaultValue,
+    });
+
+    expect(result).toEqual({ kind: 'path', path: outputPath });
+    expect(existsSync(outputPath)).toBe(true);
+  });
+
   it('should reject unsupported commands without skill subcommand', async () => {
     const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-workspace-'));
     const homeDir = mkdtempSync(join(tmpdir(), 'facet-home-'));

--- a/src/__tests__/module-boundary.test.ts
+++ b/src/__tests__/module-boundary.test.ts
@@ -24,4 +24,12 @@ describe('module boundary', () => {
     expect('ensureDirectoryExists' in flowModule).toBe(false);
     expect('runTemplateApplyInstall' in modesModule).toBe(false);
   });
+
+  it('should keep composition source helpers internal to skill commands', async () => {
+    const skillCommandsModulePath = pathToFileURL(resolve('src/cli/skill-commands.ts')).href;
+    const skillCommandsModule = await import(skillCommandsModulePath);
+
+    expect('resolveCompositionSource' in skillCommandsModule).toBe(false);
+    expect('hasGlobalCompositionShadow' in skillCommandsModule).toBe(false);
+  });
 });

--- a/src/cli/compose-command.ts
+++ b/src/cli/compose-command.ts
@@ -1,0 +1,198 @@
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { compose } from '../compose.js';
+import { loadComposeDefinition } from '../compose-definition.js';
+import { formatCombinedOutput, resolveOutputDirectory, writeComposeOutput } from '../output/index.js';
+import type { ComposeDefinition } from '../types.js';
+import {
+  buildFacetSet,
+  buildSkillSections,
+  ensureSafeDefinitionName,
+} from './skill-renderer.js';
+import {
+  getSkillPaths,
+  selectCompositionDefinitionPath,
+} from './skill-commands.js';
+import type { FacetCliOptions, FacetCliResult } from './types.js';
+import {
+  copyDirectoryTree,
+  ensureRegenerationTargetDir,
+  ensureTemplateDirectoryFromRoots,
+  shouldOverwrite,
+} from './install-skill/flow.js';
+import { applyFacetTokensToPath, buildInlineFacetTokenValues } from './install-skill/facets.js';
+
+function buildComposeOutputPlans(params: {
+  safeName: string;
+  systemPrompt: string;
+  userMessage: string;
+  splitSystem: boolean;
+}): Array<{ fileName: string; content: string }> {
+  if (params.splitSystem) {
+    return [
+      {
+        fileName: `${params.safeName}.system.md`,
+        content: `${params.systemPrompt}\n`,
+      },
+      {
+        fileName: `${params.safeName}.user.md`,
+        content: `${params.userMessage}\n`,
+      },
+    ];
+  }
+
+  return [
+    {
+      fileName: `${params.safeName}.md`,
+      content: formatCombinedOutput({
+        systemPrompt: params.systemPrompt,
+        userMessage: params.userMessage,
+      }),
+    },
+  ];
+}
+
+async function runTemplateBackedCompose(params: {
+  options: FacetCliOptions;
+  facetedRoots: readonly string[];
+  facetsRoots: readonly string[];
+  definitionPath: string;
+  definition: ComposeDefinition;
+}): Promise<FacetCliResult> {
+  const templateName = params.definition.template;
+  if (!templateName) {
+    throw new Error(`Template-backed compose requires template: ${params.definition.name}`);
+  }
+
+  const templateDir = ensureTemplateDirectoryFromRoots(params.facetedRoots, templateName);
+  const outputInput = await params.options.input('Output directory', params.options.cwd);
+  const outputDir = resolveOutputDirectory(outputInput, params.options.cwd);
+  await ensureRegenerationTargetDir({
+    targetDir: outputDir,
+    options: params.options,
+    promptLabel: 'Output directory',
+  });
+
+  copyDirectoryTree(templateDir, outputDir);
+
+  const sections = buildSkillSections({
+    definition: params.definition,
+    definitionDir: dirname(params.definitionPath),
+    facetsRoots: params.facetsRoots,
+  });
+
+  applyFacetTokensToPath({
+    rootDir: outputDir,
+    maxDepth: Number.MAX_SAFE_INTEGER,
+    tokenValues: buildInlineFacetTokenValues(sections),
+    excludeDirs: [],
+  });
+
+  return {
+    kind: 'path',
+    path: outputDir,
+  };
+}
+
+async function runStandardCompose(params: {
+  options: FacetCliOptions;
+  facetsRoots: readonly string[];
+  definitionPath: string;
+  definition: ComposeDefinition;
+}): Promise<FacetCliResult> {
+  const safeName = ensureSafeDefinitionName(params.definition.name);
+
+  const facetSet = buildFacetSet({
+    definitionDir: dirname(params.definitionPath),
+    facetsRoots: params.facetsRoots,
+    definition: params.definition,
+  });
+
+  const composed = compose(facetSet, {
+    contextMaxChars: 2000,
+    userMessageOrder: params.definition.order,
+  });
+
+  const splitSelection = await params.options.select(
+    ['Combined (single file)', 'Split (system + user)'],
+    'Choose output mode with Up/Down and Enter:',
+  );
+  const outputPlans = buildComposeOutputPlans({
+    safeName,
+    systemPrompt: composed.systemPrompt,
+    userMessage: composed.userMessage,
+    splitSystem: splitSelection === 'Split (system + user)',
+  });
+  const outputInput = await params.options.input('Output directory', params.options.cwd);
+  const outputDir = resolveOutputDirectory(outputInput, params.options.cwd);
+
+  const existingPaths = outputPlans
+    .map(plan => resolve(outputDir, plan.fileName))
+    .filter(path => existsSync(path));
+  let overwrite = false;
+  if (existingPaths.length > 0) {
+    const overwriteAnswer = await params.options.input(
+      `Output file exists. Overwrite? (${existingPaths.join(', ')}) [y/N]`,
+      'n',
+    );
+    if (!shouldOverwrite(overwriteAnswer)) {
+      throw new Error(`Output file exists and overwrite was cancelled: ${existingPaths.join(', ')}`);
+    }
+    overwrite = true;
+  }
+
+  const outputPaths: string[] = [];
+  for (const plan of outputPlans) {
+    outputPaths.push(await writeComposeOutput({
+      outputDir,
+      fileName: plan.fileName,
+      content: plan.content,
+      overwrite,
+    }));
+  }
+
+  if (outputPaths.length === 1) {
+    return {
+      kind: 'path',
+      path: outputPaths[0]!,
+    };
+  }
+
+  return {
+    kind: 'paths',
+    paths: outputPaths,
+  };
+}
+
+export async function runComposeCommand(options: FacetCliOptions): Promise<FacetCliResult> {
+  const { facetedRoots, facetsRoots, compositionsDirs } = getSkillPaths(options.cwd, options.homeDir);
+  const localCompositionsDir = facetedRoots.length > 1 ? resolve(facetedRoots[0]!, 'compositions') : undefined;
+  const globalCompositionsDir = resolve(facetedRoots[facetedRoots.length - 1]!, 'compositions');
+
+  const { definitionPath } = await selectCompositionDefinitionPath({
+    options,
+    compositionDefinitionDirs: compositionsDirs,
+    localCompositionsDir,
+    globalCompositionsDir,
+    cancelAction: 'Compose',
+  });
+
+  const definition = await loadComposeDefinition(definitionPath);
+
+  if (definition.template) {
+    return runTemplateBackedCompose({
+      options,
+      facetedRoots,
+      facetsRoots,
+      definitionPath,
+      definition,
+    });
+  }
+
+  return runStandardCompose({
+    options,
+    facetsRoots,
+    definitionPath,
+    definition,
+  });
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,17 +1,15 @@
 import { existsSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { compose } from '../compose.js';
 import {
   initializeGlobalFaceted,
   initializeLocalFaceted,
   listPullSampleTargetPaths,
   pullSampleFacets,
 } from '../init/index.js';
-import { formatCombinedOutput, resolveOutputDirectory, writeComposeOutput } from '../output/index.js';
-import { resolveComposeContext } from './compose-context.js';
-import { buildFacetSet, ensureSafeDefinitionName } from './skill-renderer.js';
 import {
-  getSkillPaths,
+  runComposeCommand,
+} from './compose-command.js';
+import {
   runInstallSkillCommand,
 } from './skill-commands.js';
 import type { FacetCliOptions, FacetCliResult } from './types.js';
@@ -39,99 +37,6 @@ function ensureSkillSubcommand(command: string, subcommand: string | undefined):
   if (subcommand !== 'skill') {
     throw new Error(`Unsupported command: ${command}`);
   }
-}
-
-async function runComposeCommand(options: FacetCliOptions): Promise<FacetCliResult> {
-  const { facetsRoots, facetedRoots } = getSkillPaths(options.cwd, options.homeDir);
-  const composeContext = resolveComposeContext(options.cwd);
-  const definition = {
-    name: composeContext.name,
-    persona: 'coder',
-    policies: ['coding', 'ai-antipattern'],
-    knowledge: composeContext.knowledgeRefs,
-    instruction: composeContext.relatedInstruction,
-    order: ['policies', 'knowledge', 'instruction'] as const,
-  };
-  const definitionDir = facetedRoots[0];
-  if (!definitionDir) {
-    throw new Error('Faceted root is required');
-  }
-
-  const facetSet = buildFacetSet({
-    definitionDir,
-    facetsRoots,
-    definition,
-  });
-
-  const composed = compose(facetSet, {
-    contextMaxChars: 2000,
-    userMessageOrder: definition.order,
-  });
-
-  const splitSelection = await options.select(
-    ['Combined (single file)', 'Split (system + user)'],
-    'Choose output mode with Up/Down and Enter:',
-  );
-  const splitSystem = splitSelection === 'Split (system + user)';
-
-  const outputInput = await options.input('Output directory', options.cwd);
-  const outputDir = resolveOutputDirectory(outputInput, options.cwd);
-  const safeName = ensureSafeDefinitionName(definition.name);
-  const outputPlans = splitSystem
-    ? [
-        {
-          fileName: `${safeName}.system.md`,
-          content: `${composed.systemPrompt}\n`,
-        },
-        {
-          fileName: `${safeName}.user.md`,
-          content: `${composed.userMessage}\n`,
-        },
-      ]
-    : [
-        {
-          fileName: `${safeName}.md`,
-          content: formatCombinedOutput(composed),
-        },
-      ];
-  const existingPaths = outputPlans
-    .map(plan => resolve(outputDir, plan.fileName))
-    .filter(path => existsSync(path));
-  let overwrite = false;
-
-  if (existingPaths.length > 0) {
-    const overwriteAnswer = await options.input(
-      `Output file exists. Overwrite? (${existingPaths.join(', ')}) [y/N]`,
-      'n',
-    );
-
-    if (!shouldOverwrite(overwriteAnswer)) {
-      throw new Error(`Output file exists and overwrite was cancelled: ${existingPaths.join(', ')}`);
-    }
-    overwrite = true;
-  }
-
-  const outputPaths: string[] = [];
-  for (const plan of outputPlans) {
-    outputPaths.push(await writeComposeOutput({
-      outputDir,
-      fileName: plan.fileName,
-      content: plan.content,
-      overwrite,
-    }));
-  }
-
-  if (outputPaths.length === 1) {
-    return {
-      kind: 'path',
-      path: outputPaths[0]!,
-    };
-  }
-
-  return {
-    kind: 'paths',
-    paths: outputPaths,
-  };
 }
 
 export async function runFacetCli(

--- a/src/cli/skill-commands.ts
+++ b/src/cli/skill-commands.ts
@@ -8,6 +8,7 @@ import {
   listCompositionDefinitions,
 } from './skill-renderer.js';
 import type { FacetCliOptions, FacetCliResult } from './types.js';
+import { shouldOverwrite } from './install-skill/flow.js';
 import { runSkillDeployInstall } from './install-skill/modes.js';
 
 export function getSkillPaths(cwd: string, homeDir: string): {
@@ -55,14 +56,14 @@ function hasGlobalCompositionShadow(
   return false;
 }
 
-export async function runInstallSkillCommand(options: FacetCliOptions): Promise<FacetCliResult> {
-  const { facetedRoots, facetsRoots, compositionsDirs } = getSkillPaths(options.cwd, options.homeDir);
-  const localFacetedRoot = getFacetedRoot(options.cwd);
-  const globalFacetedRoot = getFacetedRoot(options.homeDir);
-  const localCompositionsDir = existsSync(localFacetedRoot) ? join(localFacetedRoot, 'compositions') : undefined;
-  const globalCompositionsDir = join(globalFacetedRoot, 'compositions');
-
-  const definitionMap = listCompositionDefinitions(compositionsDirs);
+export async function selectCompositionDefinitionPath(params: {
+  options: FacetCliOptions;
+  compositionDefinitionDirs: readonly string[];
+  localCompositionsDir: string | undefined;
+  globalCompositionsDir: string;
+  cancelAction: 'Install' | 'Compose';
+}): Promise<{ definitionPath: string }> {
+  const definitionMap = listCompositionDefinitions(params.compositionDefinitionDirs);
   const compositionCandidates = Object.keys(definitionMap)
     .sort()
     .map(name => {
@@ -70,14 +71,15 @@ export async function runInstallSkillCommand(options: FacetCliOptions): Promise<
       if (!definitionPath) {
         throw new Error(`Unknown compose definition: ${name}`);
       }
-      const source = resolveCompositionSource(definitionPath, localCompositionsDir);
+      const source = resolveCompositionSource(definitionPath, params.localCompositionsDir);
       return source === 'local' ? `${name} (local)` : `${name} (global)`;
     });
+
   if (compositionCandidates.length === 0) {
-    throw new Error(`No compose definitions found in ${compositionsDirs.join(', ')}`);
+    throw new Error(`No compose definitions found in ${params.compositionDefinitionDirs.join(', ')}`);
   }
 
-  const selectedLabel = await options.select(
+  const selectedLabel = await params.options.select(
     compositionCandidates,
     'Choose composition with Up/Down and Enter:',
   );
@@ -88,18 +90,35 @@ export async function runInstallSkillCommand(options: FacetCliOptions): Promise<
   }
 
   if (
-    resolveCompositionSource(definitionPath, localCompositionsDir) === 'local' &&
-    hasGlobalCompositionShadow(selectedComposition, globalCompositionsDir)
+    resolveCompositionSource(definitionPath, params.localCompositionsDir) === 'local' &&
+    hasGlobalCompositionShadow(selectedComposition, params.globalCompositionsDir)
   ) {
-    const approved = await options.input(
+    const approved = await params.options.input(
       `Local composition "${selectedComposition}" overrides global definition. Continue? [y/N]`,
       'n',
     );
-    const normalized = approved.trim().toLowerCase();
-    if (normalized !== 'y' && normalized !== 'yes') {
-      throw new Error(`Install was cancelled for local composition: ${selectedComposition}`);
+    if (!shouldOverwrite(approved)) {
+      throw new Error(`${params.cancelAction} was cancelled for local composition: ${selectedComposition}`);
     }
   }
+
+  return { definitionPath };
+}
+
+export async function runInstallSkillCommand(options: FacetCliOptions): Promise<FacetCliResult> {
+  const { facetedRoots, facetsRoots, compositionsDirs } = getSkillPaths(options.cwd, options.homeDir);
+  const localFacetedRoot = getFacetedRoot(options.cwd);
+  const globalFacetedRoot = getFacetedRoot(options.homeDir);
+  const localCompositionsDir = existsSync(localFacetedRoot) ? join(localFacetedRoot, 'compositions') : undefined;
+  const globalCompositionsDir = join(globalFacetedRoot, 'compositions');
+
+  const { definitionPath } = await selectCompositionDefinitionPath({
+    options,
+    compositionDefinitionDirs: compositionsDirs,
+    localCompositionsDir,
+    globalCompositionsDir,
+    cancelAction: 'Install',
+  });
 
   const definition = await loadComposeDefinition(definitionPath);
   const safeSkillName = ensureSafeDefinitionName(definition.name);


### PR DESCRIPTION
## Summary

## 概要

`facet compose` コマンドを `facet install skill` と同様に compositions ディレクトリから定義を選択してプロンプトファイルを出力できるように拡張する。

## 現状の問題

- `facet compose` は CWD コンテキストの自動検出 + ハードコードされたファセット（`persona: 'coder'`, `policies: ['coding', 'ai-antipattern']`）でしか動作しない
- compositions を使った compose ができない
- `facet install skill` は compositions を使えるが、出力先が Claude Code / Codex のスキル形式に限定されている
- **「composition を選んで、ファセットをテンプレートに埋め込んで、素のプロンプトファイルを出力する」手段がない**

## 期待する動作

```
$ facet compose
? Choose composition with Up/Down and Enter:
  > xxx (local)
    coding (global)
    frontend (global)

? Output directory: ./prompts
→ ./xxx.yaml に出力
```

1. `install skill` と同様に compositions 一覧を表示（local/global 区別付き）
2. 選択された composition のファセットを解決
3. テンプレートがあれば `{{facet:xxx}}` トークンを置換
4. 結果をプレーンなファイルとして出力（スキル形式ではなく素のファイル）

## 補足

- テンプレートが `.yaml` の場合、マルチターン構造（few-shot 例を含む）をそのまま出力できる必要がある
- テンプレートがない composition の場合は、現行の system + user 分割出力も引き続きサポートする

## Execution Report

Piece `takt-default` completed successfully.

Closes #19