### PR TITLE
[#23] add-template-auto-indent

### DIFF
--- a/src/__tests__/install-skill-facets.test.ts
+++ b/src/__tests__/install-skill-facets.test.ts
@@ -13,6 +13,13 @@ function tokenValues() {
   };
 }
 
+function multilineTokenValues() {
+  return {
+    ...tokenValues(),
+    persona: 'Persona Line 1\nPersona Line 2\nPersona Line 3',
+  };
+}
+
 describe('applyFacetTokens*', () => {
   it('should apply the same token replacement result for scan mode and file-list mode', () => {
     const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-facets-'));
@@ -72,6 +79,168 @@ describe('applyFacetTokens*', () => {
         rootDir: outputDir,
       })).toThrow(`Symbolic links are not allowed in Output directory path: ${symlinkPath}`);
       expect(readFileSync(outsidePath, 'utf-8')).toBe('{{facet:persona}}');
+    } finally {
+      rmSync(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should keep placeholder indentation for multiline facet values by default', () => {
+    const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-facets-'));
+
+    try {
+      const outputPath = join(workspaceDir, 'prompt.yaml');
+      writeFileSync(
+        outputPath,
+        ['persona: |', '  {{facet:persona}}'].join('\n'),
+        'utf-8',
+      );
+
+      applyFacetTokensToFiles({
+        filePaths: [outputPath],
+        tokenValues: multilineTokenValues(),
+        rootDir: workspaceDir,
+      });
+
+      expect(readFileSync(outputPath, 'utf-8')).toBe(
+        ['persona: |', '  Persona Line 1', '  Persona Line 2', '  Persona Line 3'].join('\n'),
+      );
+    } finally {
+      rmSync(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should skip auto indentation when indent:none modifier is specified', () => {
+    const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-facets-'));
+
+    try {
+      const outputPath = join(workspaceDir, 'prompt.yaml');
+      writeFileSync(
+        outputPath,
+        ['persona: |', '  {{facet:persona | indent:none}}'].join('\n'),
+        'utf-8',
+      );
+
+      applyFacetTokensToFiles({
+        filePaths: [outputPath],
+        tokenValues: multilineTokenValues(),
+        rootDir: workspaceDir,
+      });
+
+      expect(readFileSync(outputPath, 'utf-8')).toBe(
+        ['persona: |', '  Persona Line 1', 'Persona Line 2', 'Persona Line 3'].join('\n'),
+      );
+    } finally {
+      rmSync(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should keep multiline values unchanged when placeholder line has no indentation', () => {
+    const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-facets-'));
+
+    try {
+      const outputPath = join(workspaceDir, 'prompt.yaml');
+      writeFileSync(
+        outputPath,
+        'persona={{facet:persona}}',
+        'utf-8',
+      );
+
+      applyFacetTokensToFiles({
+        filePaths: [outputPath],
+        tokenValues: multilineTokenValues(),
+        rootDir: workspaceDir,
+      });
+
+      expect(readFileSync(outputPath, 'utf-8')).toBe(
+        'persona=Persona Line 1\nPersona Line 2\nPersona Line 3',
+      );
+    } finally {
+      rmSync(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should not add whitespace to blank lines inside multiline facet values', () => {
+    const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-facets-'));
+
+    try {
+      const outputPath = join(workspaceDir, 'prompt.yaml');
+      writeFileSync(
+        outputPath,
+        ['persona: |', '  {{facet:persona}}'].join('\n'),
+        'utf-8',
+      );
+
+      applyFacetTokensToFiles({
+        filePaths: [outputPath],
+        tokenValues: {
+          ...tokenValues(),
+          persona: 'Persona Line 1\n\nPersona Line 3',
+        },
+        rootDir: workspaceDir,
+      });
+
+      expect(readFileSync(outputPath, 'utf-8')).toBe(
+        ['persona: |', '  Persona Line 1', '', '  Persona Line 3'].join('\n'),
+      );
+    } finally {
+      rmSync(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should apply indentation independently for each placeholder line', () => {
+    const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-facets-'));
+
+    try {
+      const outputPath = join(workspaceDir, 'prompt.yaml');
+      writeFileSync(
+        outputPath,
+        ['top:', '  {{facet:persona}}', 'nested:', '    {{facet:persona}}'].join('\n'),
+        'utf-8',
+      );
+
+      applyFacetTokensToFiles({
+        filePaths: [outputPath],
+        tokenValues: multilineTokenValues(),
+        rootDir: workspaceDir,
+      });
+
+      expect(readFileSync(outputPath, 'utf-8')).toBe(
+        [
+          'top:',
+          '  Persona Line 1',
+          '  Persona Line 2',
+          '  Persona Line 3',
+          'nested:',
+          '    Persona Line 1',
+          '    Persona Line 2',
+          '    Persona Line 3',
+        ].join('\n'),
+      );
+    } finally {
+      rmSync(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should keep token untouched when indent:auto modifier is explicitly specified', () => {
+    const workspaceDir = mkdtempSync(join(tmpdir(), 'facet-facets-'));
+
+    try {
+      const outputPath = join(workspaceDir, 'prompt.yaml');
+      writeFileSync(
+        outputPath,
+        ['persona: |', '  {{facet:persona | indent:auto}}'].join('\n'),
+        'utf-8',
+      );
+
+      applyFacetTokensToFiles({
+        filePaths: [outputPath],
+        tokenValues: multilineTokenValues(),
+        rootDir: workspaceDir,
+      });
+
+      expect(readFileSync(outputPath, 'utf-8')).toBe(
+        ['persona: |', '  {{facet:persona | indent:auto}}'].join('\n'),
+      );
     } finally {
       rmSync(workspaceDir, { recursive: true, force: true });
     }

--- a/src/__tests__/module-boundary.test.ts
+++ b/src/__tests__/module-boundary.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { describe, expect, it } from 'vitest';
@@ -31,5 +32,12 @@ describe('module boundary', () => {
 
     expect('resolveCompositionSource' in skillCommandsModule).toBe(false);
     expect('hasGlobalCompositionShadow' in skillCommandsModule).toBe(false);
+  });
+
+  it('should keep install facets orchestration file within size boundary', () => {
+    const facetsModulePath = resolve('src/cli/install-skill/facets.ts');
+    const lineCount = readFileSync(facetsModulePath, 'utf-8').split('\n').length;
+
+    expect(lineCount).toBeLessThanOrEqual(300);
   });
 });

--- a/src/cli/install-skill/facet-token-renderer.ts
+++ b/src/cli/install-skill/facet-token-renderer.ts
@@ -1,0 +1,54 @@
+type FacetPlaceholderKey = 'persona' | 'knowledges' | 'policies' | 'instructions';
+
+export type FacetTokenValues = Record<FacetPlaceholderKey, string>;
+
+const FACET_TOKEN_PATTERN =
+  /{{\s*facet:(persona|knowledges|policies|instructions)(?:\s*\|\s*indent:(none))?\s*}}/g;
+const FACET_TOKEN_TEST =
+  /{{\s*facet:(persona|knowledges|policies|instructions)(?:\s*\|\s*indent:(none))?\s*}}/;
+
+export function hasFacetToken(content: string): boolean {
+  return FACET_TOKEN_TEST.test(content);
+}
+
+export function replaceFacetTokens(content: string, values: FacetTokenValues): string {
+  return content.replaceAll(
+    FACET_TOKEN_PATTERN,
+    (
+      _match: string,
+      token: FacetPlaceholderKey,
+      indentMode: 'none' | undefined,
+      offset: number,
+      source: string,
+    ) => {
+      const value = values[token];
+      if (indentMode === 'none') {
+        return value;
+      }
+      const lineIndent = detectPlaceholderLineIndent(source, offset);
+      return applyAutoIndentToMultilineValue(value, lineIndent);
+    },
+  );
+}
+
+function detectPlaceholderLineIndent(source: string, offset: number): string {
+  const lineStart = source.lastIndexOf('\n', offset - 1) + 1;
+  const linePrefix = source.slice(lineStart, offset);
+  return /^\s*$/.test(linePrefix) ? linePrefix : '';
+}
+
+function applyAutoIndentToMultilineValue(value: string, lineIndent: string): string {
+  if (lineIndent === '' || !value.includes('\n')) {
+    return value;
+  }
+
+  const lines = value.split('\n');
+  return lines
+    .map((line, index) => {
+      if (index === 0 || line === '') {
+        return line;
+      }
+      return `${lineIndent}${line}`;
+    })
+    .join('\n');
+}

--- a/src/cli/install-skill/facets.ts
+++ b/src/cli/install-skill/facets.ts
@@ -14,12 +14,8 @@ import {
   resolveBoundedOutputFilePath,
   writeUtf8FileWithoutFollowingSymbolicLinks,
 } from './facet-token-file-ops.js';
-
-const FACET_TOKEN_PATTERN = /{{facet:(persona|knowledges|policies|instructions)}}/g;
-const FACET_TOKEN_TEST = /{{facet:(persona|knowledges|policies|instructions)}}/;
-
-type FacetPlaceholderKey = 'persona' | 'knowledges' | 'policies' | 'instructions';
-type FacetTokenValues = Record<FacetPlaceholderKey, string>;
+import { hasFacetToken, replaceFacetTokens } from './facet-token-renderer.js';
+import type { FacetTokenValues } from './facet-token-renderer.js';
 
 export type SkillSections = ReturnType<typeof buildSkillSections>;
 
@@ -67,12 +63,6 @@ export function buildInlineFacetTokenValues(sections: SkillSections): FacetToken
   };
 }
 
-function replaceFacetTokens(content: string, values: FacetTokenValues): string {
-  return content.replaceAll(FACET_TOKEN_PATTERN, (_match, token: FacetPlaceholderKey) => {
-    return values[token];
-  });
-}
-
 function applyFacetTokensToSingleFile(params: {
   filePath: string;
   tokenValues: FacetTokenValues;
@@ -80,7 +70,7 @@ function applyFacetTokensToSingleFile(params: {
 }): void {
   const boundedPath = resolveBoundedOutputFilePath(params.filePath, params.rootDir);
   const original = readUtf8FileWithoutFollowingSymbolicLinks(boundedPath.filePath);
-  if (!FACET_TOKEN_TEST.test(original)) {
+  if (!hasFacetToken(original)) {
     return;
   }
 


### PR DESCRIPTION
## Summary

## Summary
When a template placeholder like `{{facet:persona}}` expands to multiple lines, only the first line is positioned correctly. Subsequent lines do not preserve the placeholder line indentation, which makes YAML templates awkward to use.

## Problem
Given a template such as:

```yaml
persona: |
  {{facet:persona}}
```

if `persona` is multiline, the lines after the first one are not indented to match the placeholder position. In practice, the natural expectation is that multiline facet content keeps the left indentation of the placeholder line.

## Proposed behavior
Make template facet placeholders use auto indentation by default.

- `{{facet:persona}}` should behave as `indent:auto`
- `indent:auto` means: when the rendered value spans multiple lines, lines after the first inherit the left indentation of the placeholder line
- provide an explicit opt-out: `{{facet:persona | indent:none}}`

## Why this direction
- This matches the most common expectation for YAML-oriented templates
- It keeps template authoring simple in the common case
- Indentation concerns belong at the template site, not in composition-level config
- An explicit opt-out is enough for cases where raw insertion is desired

## Scope
Initial scope can be limited to:
- default auto-indent for `{{facet:...}}`
- `indent:none` opt-out

Fixed-width indentation such as `indent:4` does not seem necessary at this stage and can be deferred unless a concrete use case appears.

## Execution Report

Piece `takt-default` completed successfully.

Closes #23