### PR TITLE
Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-03-18
+
+### Added
+- ローカル `.faceted/` ディレクトリのサポート。プロジェクトディレクトリ直下の `.faceted/` にファセットや compositions を配置でき、グローバル `~/.faceted/` へのフォールバック付きで先に解決される
+- `facet init` がカレントディレクトリにローカル `.faceted/` を作成するよう変更。グローバル初期化は `facet init global` で実行
+- テンプレートのファセットトークン (`{{facet:xxx}}`) が複数行の値を自動インデントするようになった。プレースホルダの行頭インデントに合わせて後続行にインデントが適用される。`{{facet:xxx | indent:none}}` で無効化可能 (#24)
+- CLI 起動時にパッケージの新バージョンを自動チェックする update notifier を追加 (#18)
+
+### Changed
+- `facet compose` が composition 定義の `template` フィールドに基づくテンプレートベースの合成に対応。ローカル/グローバル両方の compositions ディレクトリからの選択が可能に (#20)
+- ファセット解決がローカル優先の複数ルート (`facetsRoots`) に対応。ローカル `.faceted/facets/` → グローバル `~/.faceted/facets/` の順で first-match-wins (#20)
+- テンプレートファイルコピー時のファイルレベル上書き確認とシンボリックリンクチェックによるセキュリティ強化 (#22)
+
+### Internal
+- `compose` コマンドを `compose-command.ts` に分離しモジュール化
+- ファセットトークン処理を `facet-token-renderer.ts` / `facet-token-file-ops.ts` に分離
+- テストカバレッジ追加: runner, path-guard, update-check, install-skill facets/flow, module-boundary, skill-renderer regression
+
 ## [0.2.1] - 2026-03-12
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -63,8 +63,11 @@ const result = compose(
 ### As a CLI
 
 ```bash
-# Create local defaults under ~/.faceted
+# Create local .faceted/ in current directory
 facet init
+
+# Initialize global ~/.faceted/ and pull sample facets
+facet init global
 
 # Pull sample facets from TAKT on GitHub
 facet pull-sample
@@ -76,10 +79,19 @@ facet compose
 facet install skill
 ```
 
-`facet init` creates `~/.faceted/` with config and empty directories. Run `facet pull-sample` to populate sample facets, compositions, and templates:
+`facet init` creates `.faceted/` in the current directory with config and empty directories. `facet init global` initializes `~/.faceted/` and pulls sample facets. Run `facet pull-sample` to update sample facets, compositions, and templates:
 
 ```
-~/.faceted/
+.faceted/                       # Local (per-project)
+├── config.yaml
+├── facets/
+│   ├── persona/
+│   ├── knowledge/
+│   ├── policies/
+│   └── compositions/
+└── templates/
+
+~/.faceted/                     # Global (fallback)
 ├── config.yaml
 ├── facets/
 │   ├── persona/          # Persona Markdown files
@@ -93,7 +105,8 @@ facet install skill
 
 | Command | Description |
 |---------|-------------|
-| `facet init` | Create local config and empty facet directories |
+| `facet init` | Create local `.faceted/` in current directory |
+| `facet init global` | Initialize global `~/.faceted/` and pull sample facets |
 | `facet pull-sample` | Pull sample coding facets from TAKT on GitHub |
 | `facet compose` | Auto-detect context, compose prompts, and write to files |
 | `facet install skill` | Install a skill with facets to Claude Code or Codex |
@@ -182,7 +195,16 @@ See the [API Reference](./docs/api-reference.md) for the full API surface.
 ## Project Structure
 
 ```
-~/.faceted/                     # Global config (created on first run)
+.faceted/                       # Local (per-project, created by `facet init`)
+├── config.yaml
+├── facets/
+│   ├── persona/
+│   ├── knowledge/
+│   ├── policies/
+│   └── compositions/
+└── templates/
+
+~/.faceted/                     # Global (fallback, created by `facet init global`)
 ├── config.yaml
 ├── facets/
 │   ├── persona/
@@ -192,6 +214,8 @@ See the [API Reference](./docs/api-reference.md) for the full API surface.
 ├── templates/                  # Skill install templates
 └── repertoire/                 # Installed repertoire packages
 ```
+
+Facet resolution is local-first: local `.faceted/facets/` is checked before global `~/.faceted/facets/`.
 
 ## Documentation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "faceted-prompting",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "faceted-prompting",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "traced-config": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "faceted-prompting",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Faceted Prompting — structured prompt composition for LLMs",
   "type": "module",
   "main": "dist/index.js",
@@ -56,6 +56,5 @@
     "traced-config": "^0.1.0",
     "update-notifier": "^7.3.1",
     "yaml": "^2.8.1"
-  },
-  "packageManager": "pnpm@10.32.1+sha512.a706938f0e89ac1456b6563eab4edf1d1faf3368d1191fc5c59790e96dc918e4456ab2e67d613de1043d2e8c81f87303e6b40d4ffeca9df15ef1ad567348f2be"
+  }
 }


### PR DESCRIPTION
## Changes

### Added
- ローカル `.faceted/` ディレクトリのサポート。プロジェクトディレクトリ直下の `.faceted/` にファセットや compositions を配置でき、グローバル `~/.faceted/` へのフォールバック付きで先に解決される
- `facet init` がカレントディレクトリにローカル `.faceted/` を作成するよう変更。グローバル初期化は `facet init global` で実行
- テンプレートのファセットトークン (`{{facet:xxx}}`) が複数行の値を自動インデントするようになった。プレースホルダの行頭インデントに合わせて後続行にインデントが適用される。`{{facet:xxx | indent:none}}` で無効化可能 (#24)
- CLI 起動時にパッケージの新バージョンを自動チェックする update notifier を追加 (#18)

### Changed
- `facet compose` が composition 定義の `template` フィールドに基づくテンプレートベースの合成に対応。ローカル/グローバル両方の compositions ディレクトリからの選択が可能に (#20)
- ファセット解決がローカル優先の複数ルート (`facetsRoots`) に対応。ローカル `.faceted/facets/` → グローバル `~/.faceted/facets/` の順で first-match-wins (#20)
- テンプレートファイルコピー時のファイルレベル上書き確認とシンボリックリンクチェックによるセキュリティ強化 (#22)

### Internal
- `compose` コマンドを `compose-command.ts` に分離しモジュール化
- ファセットトークン処理を `facet-token-renderer.ts` / `facet-token-file-ops.ts` に分離
- テストカバレッジ追加: runner, path-guard, update-check, install-skill facets/flow, module-boundary, skill-renderer regression

## Commits

- 4906a04 takt: add-template-auto-indent (#24)
- b202d7c [#21] file-level-template-overwrite (#22)
- 0258a06 Merge pull request #20 from nrslib/takt/19/extend-compose-compositions
- 6a31cc3 takt: extend-compose-compositions
- 8460fa2 Merge pull request #18 from nrslib/takt/16/add-update-notifier
- 363e049 takt: local-default-facet-init (#17)
- 08a8752 takt: add-update-notifier