### PR TITLE
Release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-03-19
+
+### Changed
+- **BREAKING:** `instruction`（単数・文字列）を `instructions`（複数形・配列）に統一。compose 定義 YAML の `instruction: "..."` は `instructions: ["..."]` に変更が必要
+- デフォルトのユーザーメッセージ順序を `knowledge → instructions → policies` に変更。ポリシーが出力直前の制約として配置されるようになった
+- `template` フィールドでパス指定（`./`, `../`, `~`, `/`）に対応。テンプレートをプロジェクトローカルに配置可能に
+
+### Fixed
+- macOS の symlink パス不一致によりローカル composition が正しく検出されない問題を修正
+
 ## [0.3.0] - 2026-03-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -51,13 +51,13 @@ const result = compose(
     persona: { body: 'You are a senior TypeScript developer.' },
     policies: [{ body: 'Follow clean code principles. No any types.' }],
     knowledge: [{ body: 'The project uses Vitest for testing.' }],
-    instruction: { body: 'Implement a retry function with exponential backoff.' },
+    instructions: [{ body: 'Implement a retry function with exponential backoff.' }],
   },
   { contextMaxChars: 8000 },
 );
 
 // result.systemPrompt → "You are a senior TypeScript developer."
-// result.userMessage  → policies + knowledge + instruction (in order)
+// result.userMessage  → knowledge + instructions + policies (in order)
 ```
 
 ### As a CLI
@@ -88,6 +88,7 @@ facet install skill
 │   ├── persona/
 │   ├── knowledge/
 │   ├── policies/
+│   ├── instructions/
 │   └── compositions/
 └── templates/
 
@@ -97,6 +98,7 @@ facet install skill
 │   ├── persona/          # Persona Markdown files
 │   ├── knowledge/        # Domain knowledge files
 │   ├── policies/         # Policy/rules files
+│   ├── instructions/     # Instruction files
 │   └── compositions/     # Compose definition YAML files
 └── templates/            # Skill templates
 ```
@@ -125,16 +127,17 @@ knowledge:
   - architecture
 policies:
   - quality
-instruction: Summarize release impact.
+instructions:
+  - release-summary
 order:
   - knowledge
+  - instructions
   - policies
-  - instruction
 ```
 
 - `name` and `persona` are required.
-- `order` controls user-message section order (default: `policies` → `knowledge` → `instruction`).
-- `instruction` can be a facet file reference or inline text.
+- `order` controls user-message section order (default: `knowledge` → `instructions` → `policies`).
+- `instructions` is a list of facet file references.
 
 ## Scope References
 
@@ -201,6 +204,7 @@ See the [API Reference](./docs/api-reference.md) for the full API surface.
 │   ├── persona/
 │   ├── knowledge/
 │   ├── policies/
+│   ├── instructions/
 │   └── compositions/
 └── templates/
 
@@ -210,6 +214,7 @@ See the [API Reference](./docs/api-reference.md) for the full API surface.
 │   ├── persona/
 │   ├── knowledge/
 │   ├── policies/
+│   ├── instructions/
 │   └── compositions/
 ├── templates/                  # Skill install templates
 └── repertoire/                 # Installed repertoire packages

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "faceted-prompting",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "faceted-prompting",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "traced-config": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "faceted-prompting",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Faceted Prompting — structured prompt composition for LLMs",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Changes

### Changed
- **BREAKING:** `instruction`（単数・文字列）を `instructions`（複数形・配列）に統一。compose 定義 YAML の `instruction: "..."` は `instructions: ["..."]` に変更が必要
- デフォルトのユーザーメッセージ順序を `knowledge → instructions → policies` に変更。ポリシーが出力直前の制約として配置されるようになった
- `template` フィールドでパス指定（`./`, `../`, `~`, `/`）に対応。テンプレートをプロジェクトローカルに配置可能に

### Fixed
- macOS の symlink パス不一致によりローカル composition が正しく検出されない問題を修正

## Commits

- ba3c35e Release v0.3.1
- 387dc9e デフォルト順序を knowledge → instructions → policies に変更
- 20b18ab template もパス指定に対応（isResourcePath による解決を追加）
- 8504958 macOS symlink パス不一致によるローカル composition 検出失敗を修正
- dc26892 instruction を instructions（複数形・配列）に統一