### PR TITLE
Release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-04-01
+
+### Added
+- `facet compose` に非対話モードを追加。`--composition`, `--split`/`--combined`, `--output`, `--overwrite` オプションでスクリプトやCI からの利用が可能に (#28)
+
+### Changed
+- スキルインストール先パスを設定ファイル (`config.yaml`) で管理するよう変更。`install.targets.codex.roots` で Codex のインストール先ディレクトリを指定可能に (#27)
+
+### Internal
+- `compose-command.ts` を `compose-definition-resolution.ts`, `compose-execution.ts`, `compose-options.ts` に分割リファクタリング
+- TAKT quality gate 設定ファイルを追加
+- CLI の不要な stdout 出力を除去
+
 ## [0.3.1] - 2026-03-19
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ order:
 
 - `name` and `persona` are required.
 - `order` controls user-message section order (default: `knowledge` → `instructions` → `policies`).
-- `instructions` is a list of facet file references.
+- `instructions` is a list of facet names, file paths, or inline text.
 
 ## Scope References
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -54,7 +54,7 @@ Compose prompts using auto-detected project context.
 facet compose
 ```
 
-**Flow:**
+**Flow (interactive):**
 
 1. Detects related files from the working tree and selects a context (`coding` / `frontend` / `backend`)
 2. Prompts for output directory (default: current working directory)
@@ -64,6 +64,24 @@ facet compose
 4. If the target file exists, prompts for overwrite confirmation
 
 The compose context always includes the `coder` persona, `coding` and `ai-antipattern` policies, and `architecture` knowledge. When frontend- or backend-related files are detected, additional knowledge facets are included.
+
+**Non-interactive mode:**
+
+When any of the following options are specified, compose runs without prompts:
+
+```bash
+facet compose --composition <name> --split --output ./out --overwrite
+```
+
+| Option | Description |
+|--------|-------------|
+| `--composition <name>` | Select a composition definition by name |
+| `--split` | Output as split files (system + user) |
+| `--combined` | Output as a single combined file |
+| `--output <dir>` | Output directory (default: current working directory) |
+| `--overwrite` | Overwrite existing files without confirmation |
+
+`--split` and `--combined` are mutually exclusive. For standard (non-template) compose, one of them is required in non-interactive mode. Template-backed compose does not support `--split` or `--combined`.
 
 ### `facet install skill`
 
@@ -79,7 +97,7 @@ facet install skill
 2. Prompts to select a composition
 3. Prompts to select a target:
    - **Claude Code** — installs to `~/.claude/skills/{name}/SKILL.md`
-   - **Codex** — installs to `~/.agents/skills/{name}/SKILL.md`
+   - **Codex** — installs to `~/.agents/skills/{name}/SKILL.md` (configurable via `install.targets.codex.roots` in `config.yaml`)
 4. Copies facet files and generates the skill document
 
 When a composition definition includes a `template` field, install still targets Claude Code or Codex, but it copies the template directory structure and injects facet tokens (`{{facet:persona}}`, `{{facet:knowledges}}`, `{{facet:policies}}`, `{{facet:instructions}}`).
@@ -98,12 +116,13 @@ knowledge:                   # Optional: knowledge facet names or paths
 policies:                    # Optional: policy facet names or paths
   - coding
   - security
-instruction: Review changes. # Optional: inline text or file path
+instructions:                # Optional: instruction facet names, paths, or inline text
+  - review-changes
 template: issue-worktree     # Optional: template directory name
 order:                       # Optional: user-message section order
   - policies
   - knowledge
-  - instruction
+  - instructions
 ```
 
 ### Field resolution
@@ -111,4 +130,4 @@ order:                       # Optional: user-message section order
 - **Facet names** (e.g., `coder`) are resolved from `~/.faceted/facets/{kind}/{name}.md`
 - **File paths** starting with `./`, `../`, `/`, `~` or ending with `.md` are resolved directly
 - **Scope references** (`@owner/repo/name`) are resolved from `~/.faceted/repertoire/`
-- **Inline text** (for `instruction` only) is used directly without file lookup
+- **Inline text** (for `instructions` only) is used directly without file lookup

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "faceted-prompting",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "faceted-prompting",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "traced-config": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "faceted-prompting",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Faceted Prompting — structured prompt composition for LLMs",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Changes

### Added
- `facet compose` に非対話モードを追加。`--composition`, `--split`/`--combined`, `--output`, `--overwrite` オプションでスクリプトやCI からの利用が可能に (#28)

### Changed
- スキルインストール先パスを設定ファイル (`config.yaml`) で管理するよう変更。`install.targets.codex.roots` で Codex のインストール先ディレクトリを指定可能に (#27)

### Internal
- `compose-command.ts` を `compose-definition-resolution.ts`, `compose-execution.ts`, `compose-options.ts` に分割リファクタリング
- TAKT quality gate 設定ファイルを追加
- CLI の不要な stdout 出力を除去

## Commits

- 76112f1 Release v0.4.0
- e95649e [#27] update-skill-install-path (#32)
- 3e4ca67 takt: remove-stdout-output (#31)
- eae002f [#28] add-noninteractive-compose (#29)
- d681745 Add TAKT quality gate config

## Closes

(#27, #28 は既にクローズ済み)