### PR TITLE
Release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-06-19
+
+### Added
+- 第5のファセットとして output contracts（出力契約）を追加。回答・レポートの出力フォーマットを `output-contracts/` ファセットとして分離して管理でき、compose 定義 YAML の `output-contracts:` キー（TypeScript API では `outputContracts`）で指定できる。テンプレートトークン `{{facet:outputContracts}}` にも対応 (#34)
+- インストラクションファセットの部分テンプレート include を追加。`{{include:instructions/<name>}}` で `facets/partials/instructions/<name>.md` を展開でき、共通の指示文を複数のインストラクション間で再利用できる。リポジトリスコープ参照 `{{include:instructions/@owner/repo/<name>}}` にも対応。ローカル優先で解決し、include の欠落・循環参照は明示的なエラーで停止する (#35)
+- `ComposeDefinition`, `ComposeOrderEntry` 型を公開 API としてエクスポート (#34)
+
+### Changed
+- デフォルトのユーザーメッセージ順序を `knowledge → instructions → output-contracts → policies` に変更。出力契約が出力フォーマットの指示としてポリシーの直前に配置されるようになった (#34)
+
+### Internal
+- auto-tag ワークフローに `workflow_dispatch` トリガーを追加し、手動での publish を可能に
+- `.takt/config.yaml` を更新
+
 ## [0.4.0] - 2026-04-01
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "faceted-prompting",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "faceted-prompting",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "traced-config": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "faceted-prompting",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Faceted Prompting — structured prompt composition for LLMs",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Changes

### Added
- 第5のファセットとして output contracts（出力契約）を追加。回答・レポートの出力フォーマットを `output-contracts/` ファセットとして分離して管理でき、compose 定義 YAML の `output-contracts:` キー（TypeScript API では `outputContracts`）で指定できる。テンプレートトークン `{{facet:outputContracts}}` にも対応 (#34)
- インストラクションファセットの部分テンプレート include を追加。`{{include:instructions/<name>}}` で `facets/partials/instructions/<name>.md` を展開でき、共通の指示文を複数のインストラクション間で再利用できる。リポジトリスコープ参照 `{{include:instructions/@owner/repo/<name>}}` にも対応。ローカル優先で解決し、include の欠落・循環参照は明示的なエラーで停止する (#35)
- `ComposeDefinition`, `ComposeOrderEntry` 型を公開 API としてエクスポート (#34)

### Changed
- デフォルトのユーザーメッセージ順序を `knowledge → instructions → output-contracts → policies` に変更。出力契約が出力フォーマットの指示としてポリシーの直前に配置されるようになった (#34)

### Internal
- auto-tag ワークフローに `workflow_dispatch` トリガーを追加し、手動での publish を可能に
- `.takt/config.yaml` を更新

## Commits

- [#35] add-instruction-includes (#36)
- [#34] add-output-contracts-compose (#37)
- update .takt/config.yaml
- ci: add workflow_dispatch to auto-tag for manual publish
