### PR TITLE
fix: export cli/facet-includes subpath

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 *.tsbuildinfo
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./cli/facet-includes": {
+      "types": "./dist/cli/facet-includes.d.ts",
+      "import": "./dist/cli/facet-includes.js"
     }
   },
   "files": [


### PR DESCRIPTION
## Summary
- `package.json` の `exports` に `./cli/facet-includes` サブパスを追加し、外部から `faceted-prompting/cli/facet-includes` として利用可能にした
- `.gitignore` に `.DS_Store` を追加

## Test plan
- [ ] `npm run build` が成功すること
- [ ] `dist/cli/facet-includes.js` と `dist/cli/facet-includes.d.ts` が生成されること
- [ ] 外部プロジェクトから `import { ... } from 'faceted-prompting/cli/facet-includes'` で利用できること