### PR TITLE
Release v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-06-29
+
+### Fixed
+- `cli/facet-includes` モジュールが package.json の `exports` に含まれておらず、外部パッケージから `faceted-prompting/cli/facet-includes` をインポートできなかった問題を修正 (#42)
+
+### Internal
+- `.DS_Store` を `.gitignore` に追加
+
 ## [0.6.0] - 2026-06-29
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "faceted-prompting",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "faceted-prompting",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "traced-config": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "faceted-prompting",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Faceted Prompting — structured prompt composition for LLMs",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Changes

### Fixed
- `cli/facet-includes` モジュールが package.json の `exports` に含まれておらず、外部パッケージから `faceted-prompting/cli/facet-includes` をインポートできなかった問題を修正 (#42)

### Internal
- `.DS_Store` を `.gitignore` に追加

## Commits

- 2f849de Release v0.6.1
- d91f75d fix: export cli/facet-includes subpath and add .DS_Store to gitignore